### PR TITLE
Add notices for Budgeted and Actual Expenditure comparison

### DIFF
--- a/budgetportal/models.py
+++ b/budgetportal/models.py
@@ -1159,7 +1159,7 @@ class Department(models.Model):
                             'phase': phase,
                         })
 
-            missing_years = {}
+            missing_phases_count = {}
             found = False
             for fiscal_year in financial_year_starts:
                 for fiscal_phase in EXPENDITURE_TIME_SERIES_PHASES:
@@ -1176,10 +1176,10 @@ class Department(models.Model):
                                 'phase': fiscal_phase,
                                 'amount': None,
                             })
-                            if fiscal_year not in missing_years:
-                                missing_years[fiscal_year] = 1
+                            if fiscal_year not in missing_phases_count:
+                                missing_phases_count[fiscal_year] = 1
                             else:
-                                missing_years[fiscal_year] += 1
+                                missing_phases_count[fiscal_year] += 1
 
             expenditure['base_financial_year'] = FinancialYear.slug_from_year_start(str(base_year))
 
@@ -1187,7 +1187,8 @@ class Department(models.Model):
             no_data_for_years = []
             no_dept_for_years = []
             notices = []
-            for year, count in missing_years.items():
+            for year, count in missing_phases_count.items():
+                # 8 because 4 phases real and nominal
                 if count != 8:
                     # All phases for a given year must be missing before starting any checks
                     continue
@@ -1244,7 +1245,8 @@ class Department(models.Model):
     def get_expenditure_time_series_by_programme(self):
         financial_year_start = self.get_financial_year().get_starting_year()
         financial_year_start_int = int(financial_year_start)
-        financial_year_starts = [str(y) for y in xrange(financial_year_start_int - 3, financial_year_start_int + 1)]
+        year_ints = xrange(financial_year_start_int - 3, financial_year_start_int + 1)
+        financial_year_starts = [str(y) for y in year_ints]
 
         programmes = {}
 
@@ -1295,7 +1297,7 @@ class Department(models.Model):
                             })
 
             found = False
-            missing_years = {}
+            missing_phases_count = {}
             for fiscal_year in financial_year_starts:
                 for fiscal_phase in EXPENDITURE_TIME_SERIES_PHASES:
                     for program in programmes:
@@ -1311,17 +1313,17 @@ class Department(models.Model):
                                     'phase': fiscal_phase,
                                     'amount': None,
                                 })
-                                if fiscal_year not in missing_years:
-                                    missing_years[fiscal_year] = {program: 1}
+                                if fiscal_year not in missing_phases_count:
+                                    missing_phases_count[fiscal_year] = {program: 1}
                                 else:
-                                    if program not in missing_years[fiscal_year].keys():
-                                        missing_years[fiscal_year][program] = 1
+                                    if program not in missing_phases_count[fiscal_year].keys():
+                                        missing_phases_count[fiscal_year][program] = 1
                                     else:
-                                        missing_years[fiscal_year][program] += 1
+                                        missing_phases_count[fiscal_year][program] += 1
 
             no_prog_for_years = False
             notices = []
-            for year, progs in missing_years.items():
+            for year, progs in missing_phases_count.items():
                 if no_prog_for_years: break
                 for p, count in progs.items():
                     if no_prog_for_years: break

--- a/budgetportal/models.py
+++ b/budgetportal/models.py
@@ -1343,7 +1343,7 @@ class Department(models.Model):
 
             return {
                 'notices': notices,
-                'programmes': programmes.values(),
+                'programmes': sorted(programmes.values()),
                 'dataset_detail_page': dataset.get_url_path(),
             }
         else:

--- a/budgetportal/openspending.py
+++ b/budgetportal/openspending.py
@@ -80,7 +80,7 @@ class BabbageFiscalDataset():
                         aggregate_result.elapsed.microseconds / 1000)
             aggregate_result.raise_for_status()
             aggregate_result = aggregate_result.json()
-            if aggregate_result['total_cell_count'] > PAGE_SIZE:
+            if len(aggregate_result['cells']) > PAGE_SIZE:
                 raise Exception(
                     "More cells than expected - perhaps we should start paging"
                 )

--- a/budgetportal/tests/test_data/budget_and_actual.json
+++ b/budgetportal/tests/test_data/budget_and_actual.json
@@ -1434,5 +1434,1223 @@
       "vote_number.department": "National Treasury",
       "financial_year.financial_year": 2018
     }
+  ],
+  "program_test_cells_missing_2018_revenue_admin": [
+    {
+      "_count": 164,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 363629000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 69,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 3264890000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 3962941000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 525742590000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 77,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 135387000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 107,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 807090000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4562062000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 40,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 3254926000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 80,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 266104000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 9334439000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 10,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 2774593000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 169,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 375582000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 63,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 3264294000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 5,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 3967698000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 526636137000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 78,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 131290000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 108,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 774494280,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4562062000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 41,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 3546134000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 82,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 262577000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 9334439000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 9,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 2472246000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 167,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 386645000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 68,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 3265171000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 3967741000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 525742590000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 80,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 132730000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 109,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 783753000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4562062000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 41,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 3547662000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 85,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 268889000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 9334439000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 9,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 2755969000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 193,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 366665000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 87,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 3116930000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 7,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 3962941000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 519893814000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 92,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 133892000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 122,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 751362000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4542805000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 49,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 1247442000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 94,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 256965000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 9434439000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 35,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 3143863000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 165,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 467416000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 78,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 113129000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4462642000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 570833034000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 72,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 150161000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 107,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 1216758000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4812487000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 45,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4977977000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 78,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 294483000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 9363676000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 10,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 2612688000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 31,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 436312954,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 21,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 110146309,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 3,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4400158875,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 570197128000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 22,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 151181509,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 26,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 1209857964,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4812487000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 24,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4955752630,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 23,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 281778217,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 9363676000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 3,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 2478431907,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 30,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 464415800,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 23,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 113129000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 3,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4462642000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 570833034000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 23,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 156561100,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 25,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 1251758000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4812487000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 24,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4961628000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 23,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 294483000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 9363676000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 2590637000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 196,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 412661000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 90,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 107211000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 6,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4173242000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 569787416000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 87,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 146070000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 127,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 849854000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4812487000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 50,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5039068000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 93,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 286955000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 10009151000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 32,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 2634718000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 170,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 439071000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 72,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 10100312000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4835002000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 616714049000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 75,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 163991000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 109,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 1079146000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 5005639000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 41,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 5831388000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 81,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 303046000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 10218198000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 10,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 2608513000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 153,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 437869000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 56,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 10089761000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 5,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4618088000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 616347785000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 69,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 151860000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 100,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 885832697,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 5105639000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 39,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 5469838473,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 69,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 288635000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 10218198000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 9,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 2526350000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 163,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 445620000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 71,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 10100312000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4648202000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 616714049000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 76,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 163991000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 111,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 1000846000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 5105639000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 41,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 5940689000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 81,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 302296000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 10218198000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 9,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 2558513000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 203,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 414310000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 208,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 102355000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 5,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4835002000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 615856815000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 95,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 139649000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 128,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 1087876000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5005639000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 54,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5836761000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 92,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 286103000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 10218198000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 32,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 2873327000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 161,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 473819000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 61,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 101585000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 5163796000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 664004032000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 72,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 152770000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 103,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 1194148000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4763533000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 38,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 5542776000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 80,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 298047000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 11,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 3012542000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 198,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 484733000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 210,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 110418000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 5,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5163796000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 663014110000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 90,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 141009000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 126,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 1196622000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4763533000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 50,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5402120000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 170,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 290101000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 30,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 2798841000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    }
   ]
 }

--- a/budgetportal/tests/test_data/budget_and_actual.json
+++ b/budgetportal/tests/test_data/budget_and_actual.json
@@ -1,0 +1,1438 @@
+{
+  "test_cells_data_complete": [
+    {
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28726061000,
+      "_count": 557,
+      "financial_year.financial_year": 2015
+    },
+    {
+      "budget_phase.budget_phase": "Audit Outcome",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28690816280,
+      "_count": 558,
+      "financial_year.financial_year": 2015
+    },
+    {
+      "budget_phase.budget_phase": "Final Appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 29005061000,
+      "_count": 566,
+      "financial_year.financial_year": 2015
+    },
+    {
+      "budget_phase.budget_phase": "Main appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 26957304000.0,
+      "_count": 685,
+      "financial_year.financial_year": 2015
+    },
+    {
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28471417000,
+      "_count": 565,
+      "financial_year.financial_year": 2016
+    },
+    {
+      "budget_phase.budget_phase": "Audit Outcome",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28199783365,
+      "_count": 155,
+      "financial_year.financial_year": 2016
+    },
+    {
+      "budget_phase.budget_phase": "Final Appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28471416900,
+      "_count": 157,
+      "financial_year.financial_year": 2016
+    },
+    {
+      "budget_phase.budget_phase": "Main appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28471417000.0,
+      "_count": 684,
+      "financial_year.financial_year": 2016
+    },
+    {
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 40584306000,
+      "_count": 568,
+      "financial_year.financial_year": 2017
+    },
+    {
+      "budget_phase.budget_phase": "Audit Outcome",
+      "vote_number.department": "National Treasury",
+      "value.sum": 39792071170,
+      "_count": 503,
+      "financial_year.financial_year": 2017
+    },
+    {
+      "budget_phase.budget_phase": "Final Appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 40484306000,
+      "_count": 559,
+      "financial_year.financial_year": 2017
+    },
+    {
+      "budget_phase.budget_phase": "Main appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 30799220000.0,
+      "_count": 820,
+      "financial_year.financial_year": 2017
+    },
+    {
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 29710233000,
+      "_count": 536,
+      "financial_year.financial_year": 2018
+    },
+    {
+      "budget_phase.budget_phase": "Main appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 29358390000.0,
+      "_count": 882,
+      "financial_year.financial_year": 2018
+    }
+  ],
+  "test_cells_data_missing_2018": [
+    {
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28726061000,
+      "_count": 557,
+      "financial_year.financial_year": 2015
+    },
+    {
+      "budget_phase.budget_phase": "Audit Outcome",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28690816280,
+      "_count": 558,
+      "financial_year.financial_year": 2015
+    },
+    {
+      "budget_phase.budget_phase": "Final Appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 29005061000,
+      "_count": 566,
+      "financial_year.financial_year": 2015
+    },
+    {
+      "budget_phase.budget_phase": "Main appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 26957304000.0,
+      "_count": 685,
+      "financial_year.financial_year": 2015
+    },
+    {
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28471417000,
+      "_count": 565,
+      "financial_year.financial_year": 2016
+    },
+    {
+      "budget_phase.budget_phase": "Audit Outcome",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28199783365,
+      "_count": 155,
+      "financial_year.financial_year": 2016
+    },
+    {
+      "budget_phase.budget_phase": "Final Appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28471416900,
+      "_count": 157,
+      "financial_year.financial_year": 2016
+    },
+    {
+      "budget_phase.budget_phase": "Main appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 28471417000.0,
+      "_count": 684,
+      "financial_year.financial_year": 2016
+    },
+    {
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 40584306000,
+      "_count": 568,
+      "financial_year.financial_year": 2017
+    },
+    {
+      "budget_phase.budget_phase": "Audit Outcome",
+      "vote_number.department": "National Treasury",
+      "value.sum": 39792071170,
+      "_count": 503,
+      "financial_year.financial_year": 2017
+    },
+    {
+      "budget_phase.budget_phase": "Final Appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 40484306000,
+      "_count": 559,
+      "financial_year.financial_year": 2017
+    },
+    {
+      "budget_phase.budget_phase": "Main appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 30799220000.0,
+      "_count": 820,
+      "financial_year.financial_year": 2017
+    }
+  ],
+  "test_cells_only_2018": [
+    {
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 29710233000,
+      "_count": 536,
+      "financial_year.financial_year": 2018
+    },
+    {
+      "budget_phase.budget_phase": "Main appropriation",
+      "vote_number.department": "National Treasury",
+      "value.sum": 29358390000.0,
+      "_count": 882,
+      "financial_year.financial_year": 2018
+    }
+  ],
+  "program_test_cells_complete": [
+    {
+      "_count": 164,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 363629000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 69,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 3264890000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 3962941000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 525742590000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 77,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 135387000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 107,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 807090000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4562062000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 40,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 3254926000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 80,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 266104000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 9334439000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 10,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 2774593000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 169,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 375582000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 63,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 3264294000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 5,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 3967698000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 526636137000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 78,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 131290000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 108,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 774494280,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4562062000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 41,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 3546134000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 82,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 262577000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 9334439000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 9,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 2472246000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 167,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 386645000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 68,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 3265171000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 3967741000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 525742590000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 80,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 132730000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 109,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 783753000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4562062000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 41,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 3547662000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 85,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 268889000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 9334439000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 9,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 2755969000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 193,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 366665000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 87,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 3116930000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 7,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 3962941000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 519893814000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 92,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 133892000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 122,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 751362000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4542805000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 49,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 1247442000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 94,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 256965000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 9434439000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 35,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 3143863000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2015
+    },
+    {
+      "_count": 165,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 467416000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 78,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 113129000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4462642000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 570833034000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 72,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 150161000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 107,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 1216758000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4812487000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 45,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4977977000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 78,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 294483000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 9363676000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 10,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 2612688000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 31,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 436312954,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 21,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 110146309,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 3,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4400158875,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 570197128000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 22,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 151181509,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 26,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 1209857964,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4812487000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 24,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4955752630,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 23,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 281778217,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 9363676000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 3,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 2478431907,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 30,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 464415800,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 23,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 113129000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 3,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4462642000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 570833034000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 23,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 156561100,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 25,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 1251758000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4812487000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 24,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4961628000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 23,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 294483000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 9363676000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 2590637000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 196,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 412661000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 90,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 107211000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 6,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4173242000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 569787416000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 87,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 146070000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 127,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 849854000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4812487000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 50,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5039068000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 93,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 286955000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 10009151000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 32,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 2634718000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2016
+    },
+    {
+      "_count": 170,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 439071000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 72,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 10100312000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4835002000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 616714049000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 75,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 163991000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 109,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 1079146000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 5005639000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 41,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 5831388000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 81,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 303046000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 10218198000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 10,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 2608513000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 153,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 437869000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 56,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 10089761000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 5,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 4618088000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 616347785000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 69,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 151860000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 100,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 885832697,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 5105639000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 39,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 5469838473,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 69,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 288635000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 10218198000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 9,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Audit Outcome",
+      "value.sum": 2526350000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 163,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 445620000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 71,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 10100312000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 4648202000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 616714049000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 76,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 163991000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 111,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 1000846000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 5105639000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 41,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 5940689000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 81,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 302296000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 10218198000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 9,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Final Appropriation",
+      "value.sum": 2558513000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 203,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 414310000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 208,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 102355000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 5,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4835002000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 615856815000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 95,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 139649000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 128,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 1087876000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5005639000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 54,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5836761000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 92,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 286103000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 10218198000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 32,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 2873327000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2017
+    },
+    {
+      "_count": 161,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 473819000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 61,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 101585000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 5163796000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 664004032000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 72,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 152770000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 103,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 1194148000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 4763533000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 38,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 5542776000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 80,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 298047000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 9007217000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 11,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Adjusted appropriation",
+      "value.sum": 3012542000,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 198,
+      "programme_number.programme": "Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 484733000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 210,
+      "programme_number.programme": "Asset and Liability Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 110418000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 5,
+      "programme_number.programme": "Civil and Military Pensions, Contributions to Funds and Other Benefits",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5163796000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 4,
+      "programme_number.programme": "Direct charge against the National Revenue Fund",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 663014110000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 90,
+      "programme_number.programme": "Economic Policy, Tax, Financial Regulation and Research",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 141009000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 126,
+      "programme_number.programme": "Financial Accounting and Supply Chain Management Systems",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 1196622000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 2,
+      "programme_number.programme": "Financial Intelligence and State Security",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 4763533000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 50,
+      "programme_number.programme": "International Financial Relations",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 5402120000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 170,
+      "programme_number.programme": "Public Finance and Budget Management",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 290101000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 1,
+      "programme_number.programme": "Revenue Administration",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 9007217000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    },
+    {
+      "_count": 30,
+      "programme_number.programme": "Technical Support and Development Finance",
+      "budget_phase.budget_phase": "Main appropriation",
+      "value.sum": 2798841000.0,
+      "vote_number.department": "National Treasury",
+      "financial_year.financial_year": 2018
+    }
+  ]
+}

--- a/budgetportal/tests/test_department.py
+++ b/budgetportal/tests/test_department.py
@@ -32,7 +32,7 @@ class AdjustedBudgetMissingTestCase(TestCase):
         self.assertEqual(self.department.get_adjusted_budget_summary(), None)
 
 
-class AdjustedBudgetOpenSpendingtMissingTestCase(TestCase):
+class AdjustedBudgetOpenSpendingMissingTestCase(TestCase):
     """Unit tests of adjusted budget data summary for a department"""
     def setUp(self):
         year = FinancialYear(slug="2030-31")

--- a/budgetportal/tests/test_department.py
+++ b/budgetportal/tests/test_department.py
@@ -11,7 +11,7 @@ from budgetportal.models import (
 from budgetportal import models
 from django.test import TestCase
 from mock import Mock
-
+import json
 
 class AdjustedBudgetMissingTestCase(TestCase):
     """Unit tests of adjusted budget data summary for a department"""
@@ -110,6 +110,8 @@ class BudgetedAndActualExpenditureSummaryTestCase(TestCase):
     """Unit tests of budgeted and actual expenditure summary for a department"""
 
     def setUp(self):
+        with open('budgetportal/tests/test_data/budget_and_actual.json', 'r') as mock_data:
+            self.mock_data = json.load(mock_data)
         year = FinancialYear(slug="2018-19")
         sphere = Sphere(financial_year=year, name="A sphere")
         government = Government(sphere=sphere, name="A government")
@@ -124,102 +126,31 @@ class BudgetedAndActualExpenditureSummaryTestCase(TestCase):
         self.mock_openspending_api = Mock()
         self.mock_openspending_api.get_adjustment_kind_ref = Mock(return_value='adjustment_kind_ref')
         self.mock_openspending_api.get_phase_ref = Mock(return_value='budget_phase.budget_phase')
-        self.mock_openspending_api.get_programme_name_ref = Mock
+        self.mock_openspending_api.get_programme_name_ref = Mock(return_value='programme_number.programme')
         self.mock_openspending_api.get_department_name_ref = Mock(return_value='department_name_ref')
         self.mock_openspending_api.get_financial_year_ref = Mock(return_value="financial_year.financial_year")
         self.mock_openspending_api.aggregate = Mock(return_value={'cells': [{'value.sum': 1, '_count': 0}]})
-        self.mock_openspending_api.filter_dept = Mock(return_value={'cells': []})
-        self.mock_openspending_api.filter_by_ref_exclusion = Mock
-        self.mock_openspending_api.aggregate_by_three_ref = Mock(return_value=test_cells_data_complete)
+        self.mock_openspending_api.filter_dept = Mock(return_value={'cells': self.mock_data['program_test_cells_complete']})
         self.mock_openspending_api.aggregate_url = Mock
         mock_dataset.get_openspending_api = Mock(return_value=self.mock_openspending_api)
         self.department.get_expenditure_time_series_dataset = Mock(return_value=mock_dataset)
         self.department.get_financial_year = Mock(return_value=year)
 
     def test_no_cells_null_response(self):
-        self.mock_openspending_api.aggregate_by_three_ref = Mock(return_value=[])
-        result = self.department.get_expenditure_time_series_summary()
+        self.mock_openspending_api.filter_dept = Mock(return_value={'cells': []})
+        result = self.department.get_expenditure_time_series_by_programme()
         self.assertEqual(result, None)
 
     def test_complete_data_no_notices(self):
-        result = self.department.get_expenditure_time_series_summary()
+        result = self.department.get_expenditure_time_series_by_programme()
         self.assertEqual(result['notices'], [])
 
-    def test_missing_data_not_published(self):
-        """ Here we feed an incomplete set of cells and expect it to tell us that 2018 data has not been published """
-        self.mock_openspending_api.aggregate = Mock(return_value={'cells': [{'value.sum': 0, '_count': 0}]})
-        self.mock_openspending_api.aggregate_by_three_ref = Mock(return_value=test_cells_data_missing_2018)
-        result = self.department.get_expenditure_time_series_summary()
-        self.assertEqual(result['notices'], ['Please note that the data for 2018 has not been published on vulekamali.'])
-
-    def test_missing_data_dept_did_not_exist(self):
+    def test_missing_data_prog_did_not_exist(self):
         """ Here we feed an incomplete set of cells and expect it to tell us that the department did not exist
         (removed 2018 data) """
         self.mock_openspending_api.aggregate = Mock(return_value={'cells': [{'value.sum': 1, '_count': 0}]})
-        self.mock_openspending_api.aggregate_by_three_ref = Mock(return_value=test_cells_data_missing_2018)
-        result = self.department.get_expenditure_time_series_summary()
-        self.assertEqual(result['notices'], ['This department did not exist for some years displayed.'])
+        self.mock_openspending_api.filter_dept = Mock(return_value={'cells': self.mock_data['program_test_cells_missing_2018_revenue_admin']})
+        result = self.department.get_expenditure_time_series_by_programme()
+        self.assertEqual(result['notices'], ['One or more programmes did not exist for some years displayed.'])
 
 
-test_cells_data_missing_2018 = [{
-    'budget_phase.budget_phase': 'Adjusted appropriation',
-    'vote_number.department': 'National Treasury', '_count': 557,
-    'financial_year.financial_year': 2015, 'value.sum': 28726061000
-}, {
-    'budget_phase.budget_phase': 'Audit Outcome',
-    'vote_number.department': 'National Treasury', '_count': 558,
-    'financial_year.financial_year': 2015, 'value.sum': 28690816280
-}, {
-    'budget_phase.budget_phase': 'Final Appropriation',
-    'vote_number.department': 'National Treasury', '_count': 566,
-    'financial_year.financial_year': 2015, 'value.sum': 29005061000
-}, {
-    'budget_phase.budget_phase': 'Main appropriation',
-    'vote_number.department': 'National Treasury', '_count': 685,
-    'financial_year.financial_year': 2015, 'value.sum': 26957304000.0
-}, {
-    'budget_phase.budget_phase': 'Adjusted appropriation',
-    'vote_number.department': 'National Treasury', '_count': 565,
-    'financial_year.financial_year': 2016, 'value.sum': 28471417000
-}, {
-    'budget_phase.budget_phase': 'Audit Outcome',
-    'vote_number.department': 'National Treasury', '_count': 155,
-    'financial_year.financial_year': 2016, 'value.sum': 28199783365
-}, {
-    'budget_phase.budget_phase': 'Final Appropriation',
-    'vote_number.department': 'National Treasury', '_count': 157,
-    'financial_year.financial_year': 2016, 'value.sum': 28471416900
-}, {
-    'budget_phase.budget_phase': 'Main appropriation',
-    'vote_number.department': 'National Treasury', '_count': 684,
-    'financial_year.financial_year': 2016, 'value.sum': 28471417000.0
-}, {
-    'budget_phase.budget_phase': 'Adjusted appropriation',
-    'vote_number.department': 'National Treasury', '_count': 568,
-    'financial_year.financial_year': 2017, 'value.sum': 40584306000
-}, {
-    'budget_phase.budget_phase': 'Audit Outcome',
-    'vote_number.department': 'National Treasury', '_count': 503,
-    'financial_year.financial_year': 2017, 'value.sum': 39792071170
-}, {
-    'budget_phase.budget_phase': 'Final Appropriation',
-    'vote_number.department': 'National Treasury', '_count': 559,
-    'financial_year.financial_year': 2017, 'value.sum': 40484306000
-}, {
-    'budget_phase.budget_phase': 'Main appropriation',
-    'vote_number.department': 'National Treasury', '_count': 820,
-    'financial_year.financial_year': 2017, 'value.sum': 30799220000.0
-}]
-
-test_cells_only_2018 = [{
-    'budget_phase.budget_phase': 'Adjusted appropriation',
-    'vote_number.department': 'National Treasury', '_count': 536,
-    'financial_year.financial_year': 2018, 'value.sum': 29710233000
-}, {
-   'budget_phase.budget_phase': 'Main appropriation',
-   'vote_number.department': 'National Treasury', '_count': 882,
-   'financial_year.financial_year': 2018, 'value.sum': 29358390000.0
-}]
-
-
-test_cells_data_complete = test_cells_data_missing_2018 + test_cells_only_2018

--- a/budgetportal/tests/test_department.py
+++ b/budgetportal/tests/test_department.py
@@ -15,6 +15,7 @@ from mock import Mock
 
 class AdjustedBudgetMissingTestCase(TestCase):
     """Unit tests of adjusted budget data summary for a department"""
+
     def setUp(self):
         year = FinancialYear(slug="2030-31")
         sphere = Sphere(financial_year=year, name="A sphere")
@@ -34,6 +35,7 @@ class AdjustedBudgetMissingTestCase(TestCase):
 
 class AdjustedBudgetOpenSpendingMissingTestCase(TestCase):
     """Unit tests of adjusted budget data summary for a department"""
+
     def setUp(self):
         year = FinancialYear(slug="2030-31")
         sphere = Sphere(financial_year=year, name="A sphere")
@@ -55,6 +57,7 @@ class AdjustedBudgetOpenSpendingMissingTestCase(TestCase):
 
 class AdjustedBudgetTestCase(TestCase):
     """Unit tests of adjusted budget data summary for a department"""
+
     def setUp(self):
         year = FinancialYear(slug="2030-31")
         sphere = Sphere(financial_year=year, name="A sphere")
@@ -101,3 +104,122 @@ class AdjustedBudgetTestCase(TestCase):
         result = self.department.get_adjusted_budget_summary()
         self.assertEqual(result['total_change']['amount'], 11)
         self.assertEqual(result['total_change']['percentage'], 11)
+
+
+class BudgetedAndActualExpenditureSummaryTestCase(TestCase):
+    """Unit tests of budgeted and actual expenditure summary for a department"""
+
+    def setUp(self):
+        year = FinancialYear(slug="2018-19")
+        sphere = Sphere(financial_year=year, name="A sphere")
+        government = Government(sphere=sphere, name="A government")
+        self.department = Department(
+            government=government,
+            name="Fake",
+            vote_number=1,
+            is_vote_primary=True,
+            intro="",
+        )
+        mock_dataset = Mock()
+        self.mock_openspending_api = Mock()
+        self.mock_openspending_api.get_adjustment_kind_ref = Mock(return_value='adjustment_kind_ref')
+        self.mock_openspending_api.get_phase_ref = Mock(return_value='budget_phase.budget_phase')
+        self.mock_openspending_api.get_programme_name_ref = Mock
+        self.mock_openspending_api.get_department_name_ref = Mock(return_value='department_name_ref')
+        self.mock_openspending_api.get_financial_year_ref = Mock(return_value="financial_year.financial_year")
+        self.mock_openspending_api.aggregate = Mock(return_value={'cells': [{'value.sum': 1, '_count': 0}]})
+        self.mock_openspending_api.filter_dept = Mock(return_value={'cells': []})
+        self.mock_openspending_api.filter_by_ref_exclusion = Mock
+        self.mock_openspending_api.aggregate_by_three_ref = Mock(return_value=test_cells_data_complete)
+        self.mock_openspending_api.aggregate_url = Mock
+        mock_dataset.get_openspending_api = Mock(return_value=self.mock_openspending_api)
+        self.department.get_expenditure_time_series_dataset = Mock(return_value=mock_dataset)
+        self.department.get_financial_year = Mock(return_value=year)
+
+    def test_no_cells_null_response(self):
+        self.mock_openspending_api.aggregate_by_three_ref = Mock(return_value=[])
+        result = self.department.get_expenditure_time_series_summary()
+        self.assertEqual(result, None)
+
+    def test_complete_data_no_notices(self):
+        result = self.department.get_expenditure_time_series_summary()
+        self.assertEqual(result['notices'], [])
+
+    def test_missing_data_not_published(self):
+        """ Here we feed an incomplete set of cells and expect it to tell us that 2018 data has not been published """
+        self.mock_openspending_api.aggregate = Mock(return_value={'cells': [{'value.sum': 0, '_count': 0}]})
+        self.mock_openspending_api.aggregate_by_three_ref = Mock(return_value=test_cells_data_missing_2018)
+        result = self.department.get_expenditure_time_series_summary()
+        self.assertEqual(result['notices'], ['Please note that the data for 2018 has not been published on vulekamali.'])
+
+    def test_missing_data_dept_did_not_exist(self):
+        """ Here we feed an incomplete set of cells and expect it to tell us that the department did not exist
+        (removed 2018 data) """
+        self.mock_openspending_api.aggregate = Mock(return_value={'cells': [{'value.sum': 1, '_count': 0}]})
+        self.mock_openspending_api.aggregate_by_three_ref = Mock(return_value=test_cells_data_missing_2018)
+        result = self.department.get_expenditure_time_series_summary()
+        self.assertEqual(result['notices'], ['This department did not exist for some years displayed.'])
+
+
+test_cells_data_missing_2018 = [{
+    'budget_phase.budget_phase': 'Adjusted appropriation',
+    'vote_number.department': 'National Treasury', '_count': 557,
+    'financial_year.financial_year': 2015, 'value.sum': 28726061000
+}, {
+    'budget_phase.budget_phase': 'Audit Outcome',
+    'vote_number.department': 'National Treasury', '_count': 558,
+    'financial_year.financial_year': 2015, 'value.sum': 28690816280
+}, {
+    'budget_phase.budget_phase': 'Final Appropriation',
+    'vote_number.department': 'National Treasury', '_count': 566,
+    'financial_year.financial_year': 2015, 'value.sum': 29005061000
+}, {
+    'budget_phase.budget_phase': 'Main appropriation',
+    'vote_number.department': 'National Treasury', '_count': 685,
+    'financial_year.financial_year': 2015, 'value.sum': 26957304000.0
+}, {
+    'budget_phase.budget_phase': 'Adjusted appropriation',
+    'vote_number.department': 'National Treasury', '_count': 565,
+    'financial_year.financial_year': 2016, 'value.sum': 28471417000
+}, {
+    'budget_phase.budget_phase': 'Audit Outcome',
+    'vote_number.department': 'National Treasury', '_count': 155,
+    'financial_year.financial_year': 2016, 'value.sum': 28199783365
+}, {
+    'budget_phase.budget_phase': 'Final Appropriation',
+    'vote_number.department': 'National Treasury', '_count': 157,
+    'financial_year.financial_year': 2016, 'value.sum': 28471416900
+}, {
+    'budget_phase.budget_phase': 'Main appropriation',
+    'vote_number.department': 'National Treasury', '_count': 684,
+    'financial_year.financial_year': 2016, 'value.sum': 28471417000.0
+}, {
+    'budget_phase.budget_phase': 'Adjusted appropriation',
+    'vote_number.department': 'National Treasury', '_count': 568,
+    'financial_year.financial_year': 2017, 'value.sum': 40584306000
+}, {
+    'budget_phase.budget_phase': 'Audit Outcome',
+    'vote_number.department': 'National Treasury', '_count': 503,
+    'financial_year.financial_year': 2017, 'value.sum': 39792071170
+}, {
+    'budget_phase.budget_phase': 'Final Appropriation',
+    'vote_number.department': 'National Treasury', '_count': 559,
+    'financial_year.financial_year': 2017, 'value.sum': 40484306000
+}, {
+    'budget_phase.budget_phase': 'Main appropriation',
+    'vote_number.department': 'National Treasury', '_count': 820,
+    'financial_year.financial_year': 2017, 'value.sum': 30799220000.0
+}]
+
+test_cells_only_2018 = [{
+    'budget_phase.budget_phase': 'Adjusted appropriation',
+    'vote_number.department': 'National Treasury', '_count': 536,
+    'financial_year.financial_year': 2018, 'value.sum': 29710233000
+}, {
+   'budget_phase.budget_phase': 'Main appropriation',
+   'vote_number.department': 'National Treasury', '_count': 882,
+   'financial_year.financial_year': 2018, 'value.sum': 29358390000.0
+}]
+
+
+test_cells_data_complete = test_cells_data_missing_2018 + test_cells_only_2018


### PR DESCRIPTION
This PR:
- Changes the way we detect if the amount of `cells` returned is higher than the `set limit` (looks like a OpenSpending API bug, to be reported)
- ➕ Adds notices to the `Budgeted and Actual Expenditure comparison` summary section
- ➕ Adds notices to the `Budgeted and Actual Expenditure comparison` programme breakdown section
- ➕ Adds two new test cases, for a total of 7 new tests.

Notices appear for the summary section when:
- Data has not been published (`total` for a given `year` is empty)
-- E.g. `Please note that the data for 2014, 2013 and 2012 has not been published on vulekamali.`
- A department did not exist for at least one year. (`total` for a given `year` is > 0, but no data for this `dept` in this `year`)
-- E.g. `This department did not exist for some years displayed.`

A notice appears for the programme breakdown section when:
- Any programme in any year is missing data for all 4 phases.
-- `One or more programmes did not exist for some years displayed.`

Notices are presented as a list of strings in the top level of the YAML output, e.g.:
```dataset_detail_page: /datasets/bud...
  notices: ['This department did not exist for some years displayed.']
  programmes:
  - items: ...
```


📓 Notes:
- A bug was found in the OpenSpending API and [an issue was opened](https://github.com/openspending/babbage/issues/33)