### PR TITLE
Fix department website_url None bug

### DIFF
--- a/budgetportal/models.py
+++ b/budgetportal/models.py
@@ -286,7 +286,8 @@ class Department(models.Model):
 
     def get_website_url(self):
         """ Always return the latest available URL, even for old departments. """
-        return self._get_latest_department_instance().website_url
+        latest_dept = self._get_latest_department_instance()
+        return latest_dept.website_url if latest_dept else None
 
     def get_url_path(self):
         return "%s/departments/%s" % (self.government.get_url_path(), self.slug)
@@ -303,7 +304,10 @@ class Department(models.Model):
         newer_departments = Department.objects.filter(government__slug=self.government.slug,
                                                       government__sphere__slug=self.government.sphere.slug,
                                                       slug=self.slug).order_by('-government__sphere__financial_year')
-        return newer_departments.first() if newer_departments else None
+        for dept in newer_departments:
+            if dept.website_url:
+                return dept
+        return None
 
     def _get_financial_year_query(self):
         return '+vocab_financial_years:"%s"' % self.get_financial_year().slug

--- a/budgetportal/models.py
+++ b/budgetportal/models.py
@@ -83,6 +83,9 @@ class FinancialYear(models.Model):
     organisational_unit = 'financial_year'
     slug = models.SlugField(max_length=7, unique=True)
 
+    class Meta:
+        ordering = ['-slug']
+
     @property
     def national(self):
         return self.spheres.filter(slug='national')[0]
@@ -303,11 +306,8 @@ class Department(models.Model):
         Continue traversing backwards in time until found, or until the original year has been reached. """
         newer_departments = Department.objects.filter(government__slug=self.government.slug,
                                                       government__sphere__slug=self.government.sphere.slug,
-                                                      slug=self.slug).order_by('-government__sphere__financial_year')
-        for dept in newer_departments:
-            if dept.website_url:
-                return dept
-        return None
+                                                      slug=self.slug).order_by('-government__sphere__financial_year__slug')
+        return newer_departments.first() if newer_departments else None
 
     def _get_financial_year_query(self):
         return '+vocab_financial_years:"%s"' % self.get_financial_year().slug


### PR DESCRIPTION
This PR fixes a bug where the website_url for a department would show None even if one was available for a later financial year.

It was caused by the following code:
```
newer_departments = Department.objects.filter(government__slug=self.government.slug,
                                                      government__sphere__slug=self.government.sphere.slug,
                                                      slug=self.slug).order_by('-government__sphere__financial_year')
```
Where `newer_departments.first()` would not necessarily return `2018-19` but instead `2014-15`, if `2014-15` was the last year added (arbitrary, could be any date).

It is fixed by ordering by the `financial_year`'s slug, i.e.: 
`order_by('-government__sphere__financial_year__slug')`