### PR TITLE
Pdf document link fix for infrastructure projects

### DIFF
--- a/budgetportal/models.py
+++ b/budgetportal/models.py
@@ -1513,6 +1513,26 @@ class InfrastructureProject:
     def get_url_path(self):
         return "/infrastructure-projects/{}".format(self.slug)
 
+    def get_budget_document_url(self, document_format='PDF'):
+        """
+        Returns budget-vote-document URL, for given format,
+        if the latest department instance matches the project year
+        """
+        departments = Department.objects.filter(
+            slug=slugify(self.department_name),
+            government__sphere__slug='national'
+        )
+        if departments:
+            latest_dept = departments[0].get_latest_department_instance()
+            project_year = InfrastructureProject.get_dataset().package['financial_year'][0]
+            if latest_dept.get_financial_year().slug == project_year:
+                budget_dataset = latest_dept.get_dataset(group_name='budget-vote-documents')
+                if budget_dataset:
+                    document_resource = budget_dataset.get_resource(format=document_format)
+                    if document_resource:
+                        return document_resource['url']
+        return None
+
     @staticmethod
     def _calculate_projected_expenditure(records):
         """ Calculate sum of predicted amounts from a list of records """

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -414,7 +414,7 @@ def infrastructure_projects_overview(request):
     projects = []
     for project in infrastructure_projects:
         departments = Department.objects.filter(slug=slugify(project.department_name),
-                                                government__sphere__slug='national')
+                                                government__sphere__slug='national').order_by('government__sphere__financial_year')
         department_url = None
         pdf_document_url = None
         if departments:
@@ -474,8 +474,6 @@ def infrastructure_project_detail(request, project_slug):
         dept = departments[0]
         infra_project_fin_year = InfrastructureProject.get_dataset().package['financial_year'][0]
         department_url = dept.get_latest_department_instance().get_url_path()
-        print(dept.get_financial_year().slug)
-        print(infra_project_fin_year)
         if dept.get_financial_year().slug == infra_project_fin_year:
             budget_dataset = dept.get_dataset(group_name='budget-vote-documents')
             if budget_dataset:

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -413,20 +413,13 @@ def infrastructure_projects_overview(request):
         return HttpResponse(status=404)
     projects = []
     for project in infrastructure_projects:
-        departments = Department.objects.filter(slug=slugify(project.department_name),
-                                                government__sphere__slug='national').order_by('government__sphere__financial_year')
+        departments = Department.objects.filter(
+            slug=slugify(project.department_name),
+            government__sphere__slug='national'
+        )
         department_url = None
-        pdf_document_url = None
         if departments:
-            dept = departments[0]
-            infra_project_fin_year = InfrastructureProject.get_dataset().package['financial_year'][0]
-            department_url = dept.get_latest_department_instance().get_url_path()
-            if dept.get_financial_year().slug == infra_project_fin_year:
-                budget_dataset = dept.get_dataset(group_name='budget-vote-documents')
-                if budget_dataset:
-                    document_resource = budget_dataset.get_resource(format='PDF')
-                    if document_resource:
-                        pdf_document_url = document_resource['url']
+            department_url = departments[0].get_latest_department_instance().get_url_path()
 
         projects.append({
             'name': project.name,
@@ -443,7 +436,7 @@ def infrastructure_projects_overview(request):
             'department': {
                 'name': project.department_name,
                 'url': department_url,
-                'budget_document': pdf_document_url
+                'budget_document': project.get_budget_document_url()
             },
             'nature_of_investment': project.nature_of_investment,
             'infrastructure_type': project.infrastructure_type,
@@ -466,21 +459,13 @@ def infrastructure_project_detail(request, project_slug):
     project = InfrastructureProject.get_project_from_resource(project_slug)
     if project is None:
         return HttpResponse(status=404)
-    departments = Department.objects.filter(slug=slugify(project.department_name),
-                                            government__sphere__slug='national').order_by('government__sphere__financial_year')
+    departments = Department.objects.filter(
+        slug=slugify(project.department_name),
+        government__sphere__slug='national'
+    )
     department_url = None
-    pdf_document_url = None
     if departments:
-        dept = departments[0]
-        infra_project_fin_year = InfrastructureProject.get_dataset().package['financial_year'][0]
-        department_url = dept.get_latest_department_instance().get_url_path()
-        if dept.get_financial_year().slug == infra_project_fin_year:
-            budget_dataset = dept.get_dataset(group_name='budget-vote-documents')
-            if budget_dataset:
-                document_resource = budget_dataset.get_resource(format='PDF')
-                if document_resource:
-                    pdf_document_url = document_resource['url']
-
+        department_url = departments[0].get_latest_department_instance().get_url_path()
 
     project = {
         'dataset_url': InfrastructureProject.get_dataset().get_url_path(),
@@ -495,7 +480,7 @@ def infrastructure_project_detail(request, project_slug):
         'department': {
             'name': project.department_name,
             'url': department_url,
-            'budget_document': pdf_document_url
+            'budget_document': project.get_budget_document_url()
         },
         'provinces': project.get_provinces(),
         'total_budget': project.total_budget,

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -467,7 +467,7 @@ def infrastructure_project_detail(request, project_slug):
     if project is None:
         return HttpResponse(status=404)
     departments = Department.objects.filter(slug=slugify(project.department_name),
-                                            government__sphere__slug='national')
+                                            government__sphere__slug='national').order_by('government__sphere__financial_year')
     department_url = None
     pdf_document_url = None
     if departments:

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -474,6 +474,8 @@ def infrastructure_project_detail(request, project_slug):
         dept = departments[0]
         infra_project_fin_year = InfrastructureProject.get_dataset().package['financial_year'][0]
         department_url = dept.get_latest_department_instance().get_url_path()
+        print(dept.get_financial_year().slug)
+        print(infra_project_fin_year)
         if dept.get_financial_year().slug == infra_project_fin_year:
             budget_dataset = dept.get_dataset(group_name='budget-vote-documents')
             if budget_dataset:


### PR DESCRIPTION
This PR:
- Fixes a bug where the `pdf_document_url` link on the `Infrastructure Project` pages was always null in production
- Refactors the code to retrieve `pdf_document_url` into a function on the `InfrastructureProject` class