### PR TITLE
Work around Django bug #10827

### DIFF
--- a/budgetportal/settings.py
+++ b/budgetportal/settings.py
@@ -44,11 +44,11 @@ INSTALLED_APPS = (
     'budgetportal',
     'allauth_facebook',
 
+    'django.contrib.contenttypes',
     'django.contrib.auth',
     'django.contrib.sites',
     'django.contrib.admin.apps.SimpleAdminConfig',
     'adminplus',
-    'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',


### PR DESCRIPTION
Upstream bug: https://code.djangoproject.com/ticket/10827 (fixed in Django 2.2)

This was causing cascading test teardown failures locally for me. Because of the nature of the bug, it's not entirely deterministic: some ways of invoking the test suite seem to avoid it, but others reproduce it consistently. The reproducibility seems to depend on some particular module initialisation or hashing order somewhere in the Django signal code.

The bug manifests as the following error raised deep in the Django teardown code:

```
IntegrityError: insert or update on table "auth_permission" violates foreign key constraint "auth_permission_content_type_id_2f476e4b_fk_django_co"
DETAIL:  Key (content_type_id)=(1) is not present in table "django_content_type".
```

as well as several knock-on errors in following tests. Most of these seem superficially unrelated at first, but are resolved by this workaround.