### PR TITLE
Clean up .yaml endpoints

### DIFF
--- a/budgetportal/tests/test_data/test_contributed_dataset.json
+++ b/budgetportal/tests/test_data/test_contributed_dataset.json
@@ -1,0 +1,40 @@
+{
+  "count": 2,
+  "sort": "score desc, metadata_modified desc",
+  "facets": {},
+  "results": [
+    {
+      "name": "education-budget-brief-2019-20",
+      "title": "Education Budget Brief 2019/20",
+      "id": "db3ab7ec-9f62-46a6-94f9-e43f3c8536a5",
+      "metadata_created": "2019-05-13T07:10:42.235489",
+      "metadata_modified": "2019-05-14T11:32:53.564458",
+      "author": "Siyabulela Fobosi",
+      "author_email": "s.fobosi@ru.ac.za",
+      "license_title": "License not specified",
+      "resources": [],
+      "groups": [],
+      "organization": {
+        "name": "basic-organization-slug"
+      },
+      "state": ""
+    },
+    {
+      "name": "people-s-guide-to-the-adjusted-budget-2018-19",
+      "title": "People's Guide to the Adjusted Budget 2018/19",
+      "id": "9c7af295-9362-44ea-9731-b95bb1ea89d3",
+      "metadata_created": "2018-11-30T05:06:49.588395",
+      "metadata_modified": "2018-12-03T10:07:22.333285",
+      "author": "Vulekamali ",
+      "author_email": "",
+      "license_title": "Creative Commons Attribution Share-Alike",
+      "license_url": "http://www.opendefinition.org/licenses/cc-by-sa",
+      "resources": [],
+      "groups": [],
+      "organization": {
+        "name": "basic-organization-slug"
+      },
+      "state": ""
+    }
+  ]
+}

--- a/budgetportal/tests/test_data/test_contributed_dataset.json
+++ b/budgetportal/tests/test_data/test_contributed_dataset.json
@@ -1,40 +1,18 @@
 {
-  "count": 2,
-  "sort": "score desc, metadata_modified desc",
-  "facets": {},
-  "results": [
-    {
-      "name": "education-budget-brief-2019-20",
-      "title": "Education Budget Brief 2019/20",
-      "id": "db3ab7ec-9f62-46a6-94f9-e43f3c8536a5",
-      "metadata_created": "2019-05-13T07:10:42.235489",
-      "metadata_modified": "2019-05-14T11:32:53.564458",
-      "author": "Siyabulela Fobosi",
-      "author_email": "s.fobosi@ru.ac.za",
-      "license_title": "License not specified",
-      "resources": [],
-      "groups": [],
-      "organization": {
-        "name": "basic-organization-slug"
-      },
-      "state": ""
-    },
-    {
-      "name": "people-s-guide-to-the-adjusted-budget-2018-19",
-      "title": "People's Guide to the Adjusted Budget 2018/19",
-      "id": "9c7af295-9362-44ea-9731-b95bb1ea89d3",
-      "metadata_created": "2018-11-30T05:06:49.588395",
-      "metadata_modified": "2018-12-03T10:07:22.333285",
-      "author": "Vulekamali ",
-      "author_email": "",
-      "license_title": "Creative Commons Attribution Share-Alike",
-      "license_url": "http://www.opendefinition.org/licenses/cc-by-sa",
-      "resources": [],
-      "groups": [],
-      "organization": {
-        "name": "basic-organization-slug"
-      },
-      "state": ""
-    }
-  ]
+  "name": "people-s-guide-to-the-adjusted-budget-2018-19",
+  "title": "People's Guide to the Adjusted Budget 2018/19",
+  "id": "9c7af295-9362-44ea-9731-b95bb1ea89d3",
+  "metadata_created": "2018-11-30T05:06:49.588395",
+  "metadata_modified": "2018-12-03T10:07:22.333285",
+  "author": "Vulekamali ",
+  "author_email": "",
+  "license_title": "Creative Commons Attribution Share-Alike",
+  "license_url": "http://www.opendefinition.org/licenses/cc-by-sa",
+  "resources": [],
+  "groups": [],
+  "organization": {
+    "name": "basic-organization-slug"
+  },
+  "state": "",
+  "image_display_url": "test-url"
 }

--- a/budgetportal/tests/test_data/test_contributed_datasets_list.json
+++ b/budgetportal/tests/test_data/test_contributed_datasets_list.json
@@ -1,0 +1,40 @@
+{
+  "count": 2,
+  "sort": "score desc, metadata_modified desc",
+  "facets": {},
+  "results": [
+    {
+      "name": "education-budget-brief-2019-20",
+      "title": "Education Budget Brief 2019/20",
+      "id": "db3ab7ec-9f62-46a6-94f9-e43f3c8536a5",
+      "metadata_created": "2019-05-13T07:10:42.235489",
+      "metadata_modified": "2019-05-14T11:32:53.564458",
+      "author": "Siyabulela Fobosi",
+      "author_email": "s.fobosi@ru.ac.za",
+      "license_title": "License not specified",
+      "resources": [],
+      "groups": [],
+      "organization": {
+        "name": "basic-organization-slug"
+      },
+      "state": ""
+    },
+    {
+      "name": "people-s-guide-to-the-adjusted-budget-2018-19",
+      "title": "People's Guide to the Adjusted Budget 2018/19",
+      "id": "9c7af295-9362-44ea-9731-b95bb1ea89d3",
+      "metadata_created": "2018-11-30T05:06:49.588395",
+      "metadata_modified": "2018-12-03T10:07:22.333285",
+      "author": "Vulekamali ",
+      "author_email": "",
+      "license_title": "Creative Commons Attribution Share-Alike",
+      "license_url": "http://www.opendefinition.org/licenses/cc-by-sa",
+      "resources": [],
+      "groups": [],
+      "organization": {
+        "name": "basic-organization-slug"
+      },
+      "state": ""
+    }
+  ]
+}

--- a/budgetportal/tests/test_datasets.py
+++ b/budgetportal/tests/test_datasets.py
@@ -6,8 +6,11 @@ from mock import patch
 
 from budgetportal.datasets import Dataset
 
+with open('budgetportal/tests/test_data/test_contributed_datasets_list.json', 'r') as f:
+    CONTRIBUTED_DATASETS_LIST_MOCK_DATA = json.load(f)
 with open('budgetportal/tests/test_data/test_contributed_dataset.json', 'r') as f:
     CONTRIBUTED_DATASET_MOCK_DATA = json.load(f)
+
 
 class TestDataset(TestCase):
     def setUp(self):
@@ -64,7 +67,7 @@ class TestDataset(TestCase):
         """Test that it loads and that some text is present"""
         c = Client()
         with patch('budgetportal.datasets.ckan') as ckan_mock:
-            ckan_mock.action.package_search.return_value = CONTRIBUTED_DATASET_MOCK_DATA
+            ckan_mock.action.package_search.return_value = CONTRIBUTED_DATASETS_LIST_MOCK_DATA
             response = c.get('/datasets/contributed')
             content = response.content
             self.assertTrue(content.find("Education Budget Brief 2019/20"))
@@ -72,12 +75,14 @@ class TestDataset(TestCase):
             self.assertTrue(content.find("db3ab7ec-9f62-46a6-94f9-e43f3c8536a5"))
             self.assertTrue(content.find("9c7af295-9362-44ea-9731-b95bb1ea89d3"))
 
-    def test_contributed_dataset(self):
+    @patch('budgetportal.datasets.ckan.action.organization_show', return_value=CONTRIBUTED_DATASET_MOCK_DATA)
+    @patch('budgetportal.datasets.ckan.action.package_show', return_value=CONTRIBUTED_DATASET_MOCK_DATA)
+    def test_contributed_dataset(self, mock_package_show, mock_organization_show):
         """Test that it exists and that the correct years are linked"""
-        # TODO: not implemented yet
         c = Client()
-        with patch('budgetportal.datasets.ckan') as ckan_mock:
-            ckan_mock.action.package_search.return_value = CONTRIBUTED_DATASET_MOCK_DATA
-            response = c.get('/datasets/contributed/people-s-guide-to-the-adjusted-budget-2018-19')
-            content = response.content
-            self.assertTrue(content.find("Data contributed by: International Budget Partnership"))
+        response = c.get('/datasets/contributed/people-s-guide-to-the-adjusted-budget-2018-19')
+        content = response.content
+        self.assertTrue(content.find("People's Guide to the Adjusted Budget 2018/19"))
+        self.assertTrue(content.find("9c7af295-9362-44ea-9731-b95bb1ea89d3"))
+        self.assertTrue(content.find("test-url"))
+        self.assertTrue(content.find("basic-organization-slug"))

--- a/budgetportal/tests/test_datasets.py
+++ b/budgetportal/tests/test_datasets.py
@@ -1,9 +1,13 @@
+import json
+
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, Client
 from mock import patch
 
 from budgetportal.datasets import Dataset
 
+with open('budgetportal/tests/test_data/test_contributed_dataset.json', 'r') as f:
+    CONTRIBUTED_DATASET_MOCK_DATA = json.load(f)
 
 class TestDataset(TestCase):
     def setUp(self):
@@ -55,3 +59,25 @@ class TestDataset(TestCase):
 
             ckan_mock.action.package_search.assert_called_with(
                 **self.cpi_cpi_query)
+
+    def test_contributed_datasets_list(self):
+        """Test that it loads and that some text is present"""
+        c = Client()
+        with patch('budgetportal.datasets.ckan') as ckan_mock:
+            ckan_mock.action.package_search.return_value = CONTRIBUTED_DATASET_MOCK_DATA
+            response = c.get('/datasets/contributed')
+            content = response.content
+            self.assertTrue(content.find("Education Budget Brief 2019/20"))
+            self.assertTrue(content.find("People's Guide to the Adjusted Budget 2018/19"))
+            self.assertTrue(content.find("db3ab7ec-9f62-46a6-94f9-e43f3c8536a5"))
+            self.assertTrue(content.find("9c7af295-9362-44ea-9731-b95bb1ea89d3"))
+
+    def test_contributed_dataset(self):
+        """Test that it exists and that the correct years are linked"""
+        # TODO: not implemented yet
+        c = Client()
+        with patch('budgetportal.datasets.ckan') as ckan_mock:
+            ckan_mock.action.package_search.return_value = CONTRIBUTED_DATASET_MOCK_DATA
+            response = c.get('/datasets/contributed/people-s-guide-to-the-adjusted-budget-2018-19')
+            content = response.content
+            self.assertTrue(content.find("Data contributed by: International Budget Partnership"))

--- a/budgetportal/tests/test_datasets.py
+++ b/budgetportal/tests/test_datasets.py
@@ -78,7 +78,7 @@ class TestDataset(TestCase):
     @patch('budgetportal.datasets.ckan.action.organization_show', return_value=CONTRIBUTED_DATASET_MOCK_DATA)
     @patch('budgetportal.datasets.ckan.action.package_show', return_value=CONTRIBUTED_DATASET_MOCK_DATA)
     def test_contributed_dataset(self, mock_package_show, mock_organization_show):
-        """Test that it exists and that the correct years are linked"""
+        """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/datasets/contributed/people-s-guide-to-the-adjusted-budget-2018-19')
         content = response.content

--- a/budgetportal/tests/test_datasets.py
+++ b/budgetportal/tests/test_datasets.py
@@ -69,11 +69,10 @@ class TestDataset(TestCase):
         with patch('budgetportal.datasets.ckan') as ckan_mock:
             ckan_mock.action.package_search.return_value = CONTRIBUTED_DATASETS_LIST_MOCK_DATA
             response = c.get('/datasets/contributed')
-            content = response.content
-            self.assertTrue(content.find("Education Budget Brief 2019/20"))
-            self.assertTrue(content.find("People's Guide to the Adjusted Budget 2018/19"))
-            self.assertTrue(content.find("db3ab7ec-9f62-46a6-94f9-e43f3c8536a5"))
-            self.assertTrue(content.find("9c7af295-9362-44ea-9731-b95bb1ea89d3"))
+
+            self.assertContains(response, "<title>Contributed data and analysis - vulekamali</title>")
+            self.assertContains(response, "Education Budget Brief 2019/20")
+            self.assertContains(response, "People&#39;s Guide to the Adjusted Budget 2018/19")
 
     @patch('budgetportal.datasets.ckan.action.organization_show', return_value=CONTRIBUTED_DATASET_MOCK_DATA)
     @patch('budgetportal.datasets.ckan.action.package_show', return_value=CONTRIBUTED_DATASET_MOCK_DATA)
@@ -81,8 +80,9 @@ class TestDataset(TestCase):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/datasets/contributed/people-s-guide-to-the-adjusted-budget-2018-19')
-        content = response.content
-        self.assertTrue(content.find("People's Guide to the Adjusted Budget 2018/19"))
-        self.assertTrue(content.find("9c7af295-9362-44ea-9731-b95bb1ea89d3"))
-        self.assertTrue(content.find("test-url"))
-        self.assertTrue(content.find("basic-organization-slug"))
+
+        self.assertContains(response,
+                            "People&#39;s Guide to the Adjusted Budget 2018/19")
+        self.assertContains(response, "Contributed Data and Analysis")
+        self.assertContains(response, "About this dataset")
+        self.assertContains(response, "Last updated on 03 December 2018")

--- a/budgetportal/tests/test_infrastructure_projects.py
+++ b/budgetportal/tests/test_infrastructure_projects.py
@@ -1,5 +1,4 @@
 import mock
-import yaml
 from django.test import TestCase, LiveServerTestCase, Client
 
 from budgetportal.models import InfrastructureProjectPart, MAPIT_POINT_API_URL, CKAN_DATASTORE_URL
@@ -220,8 +219,8 @@ class OverviewIntegrationTest(LiveServerTestCase):
         """ Test that it exists and that the correct years are linked. """
         InfrastructureProjectPart.objects.all().delete()
         c = Client()
-        response = c.get('/infrastructure-projects.yaml')
-        content = yaml.load(response.content)
+        response = c.get('/json/infrastructure-projects.json')
+        content = response.json()
         self.assertEqual(content['projects'], [])
         self.assertEqual(content['dataset_url'], 'fake path')
         self.assertEqual(content['description'], 'Infrastructure projects in South Africa for 2019-20')
@@ -234,8 +233,8 @@ class OverviewIntegrationTest(LiveServerTestCase):
     def test_success_with_projects(self, mock_dataset, mock_get):
         """ Test that it exists and that the correct years are linked. """
         c = Client()
-        response = c.get('/infrastructure-projects.yaml')
-        content = yaml.load(response.content)
+        response = c.get('/json/infrastructure-projects.json')
+        content = response.json()
         self.assertEqual(len(content['projects']), 2)
 
         # First project (single coords, province)
@@ -281,7 +280,7 @@ class DetailIntegrationTest(LiveServerTestCase):
     @mock.patch('budgetportal.models.InfrastructureProjectPart.get_dataset', return_value=None)
     def test_missing_dataset_returns_404(self, mock_dataset):
         c = Client()
-        response = c.get('/infrastructure-projects/{}.yaml'.format(self.project.project_slug))
+        response = c.get('/json/infrastructure-projects/{}.json'.format(self.project.project_slug))
         self.assertEqual(response.status_code, 404)
 
     @mock.patch('budgetportal.models.InfrastructureProjectPart.get_dataset', return_value=MockDataset())
@@ -289,8 +288,8 @@ class DetailIntegrationTest(LiveServerTestCase):
     def test_success_with_projects(self, mock_dataset, mock_get):
         """ Test that it exists and that the correct years are linked. """
         c = Client()
-        response = c.get('/infrastructure-projects/{}.yaml'.format(self.project.project_slug))
-        content = yaml.load(response.content)['projects'][0]
+        response = c.get('/json/infrastructure-projects/{}.json'.format(self.project.project_slug))
+        content = response.json()['projects'][0]
 
         self.assertEqual(content['dataset_url'], 'fake path')
         self.assertEqual(content['description'], self.project.project_description)

--- a/budgetportal/tests/test_infrastructure_projects.py
+++ b/budgetportal/tests/test_infrastructure_projects.py
@@ -219,53 +219,45 @@ class OverviewIntegrationTest(LiveServerTestCase):
         """ Test that it exists and that the correct years are linked. """
         InfrastructureProjectPart.objects.all().delete()
         c = Client()
-        response = c.get('/json/infrastructure-projects.json')
-        content = response.json()
-        self.assertEqual(content['projects'], [])
-        self.assertEqual(content['dataset_url'], 'fake path')
-        self.assertEqual(content['description'], 'Infrastructure projects in South Africa for 2019-20')
-        self.assertEqual(content['selected_tab'], 'infrastructure-projects')
-        self.assertEqual(content['slug'], 'infrastructure-projects')
-        self.assertEqual(content['title'], 'Infrastructure Projects - vulekamali')
+        response = c.get('/infrastructure-projects')
+        content = response.content
+        self.assertTrue(content.find('fake path'))
+        self.assertTrue(content.find('Infrastructure projects in South Africa for 2019-20'))
+        self.assertTrue(content.find('Infrastructure Projects - vulekamali'))
 
     @mock.patch('budgetportal.models.InfrastructureProjectPart.get_dataset', return_value=MockDataset())
     @mock.patch('requests.get', side_effect=mocked_requests_get)
     def test_success_with_projects(self, mock_dataset, mock_get):
         """ Test that it exists and that the correct years are linked. """
         c = Client()
-        response = c.get('/json/infrastructure-projects.json')
-        content = response.json()
-        self.assertEqual(len(content['projects']), 2)
+        response = c.get('/infrastructure-projects')
+        content = response.content
 
-        # First project (single coords, province)
-        first_test_project = filter(lambda x: x['name'] == 'Standard fake project', content['projects'])[0]
-        self.assertEqual(first_test_project['description'], 'Typical project description')
-        self.assertEqual(first_test_project['detail'], '/infrastructure-projects/health-standard-fake-project')
-        self.assertEqual(first_test_project['infrastructure_type'], 'fake type')
-        
-        self.assertIn({'latitude': -31.45019, 'longitude': 29.45397}, first_test_project['coordinates'])
-        self.assertEqual(len(first_test_project['coordinates']), 1)
-        
-        self.assertEqual(len(first_test_project['expenditure']), 7)
+        # First project
+        self.assertTrue(content.find('Standard fake project'))
+        self.assertTrue(content.find('Typical project description'))
+        self.assertTrue(content.find('/infrastructure-projects/health-standard-fake-project'))
+        self.assertTrue(content.find('fake type'))
+        self.assertTrue(content.find('-31.45019'))
+        self.assertTrue(content.find('29.45397'))
+        self.assertTrue(content.find('standard fake investment'))
+        self.assertTrue(content.find('5688808000.0'))
+        self.assertTrue(content.find('Fake province 1'))
+        self.assertTrue(content.find('/infrastructure-projects/health-standard-fake-project'))
+        self.assertTrue(content.find('Fake stage'))
+        self.assertTrue(content.find('9045389000'))
+
         for item in self.standard_fake_project.build_complete_expenditure():
-            self.assertIn(item, first_test_project['expenditure'])
-        self.assertEqual(first_test_project['nature_of_investment'], 'standard fake investment')
-        self.assertEqual(first_test_project['page_title'], 'Standard fake project - vulekamali')
-        self.assertEqual(first_test_project['projected_budget'], 5688808000.0)
-        self.assertIn('Fake province 1', first_test_project['provinces'])
-        self.assertEqual(len(first_test_project['provinces']), 1)
-        self.assertEqual(first_test_project['slug'], '/infrastructure-projects/health-standard-fake-project')
-        self.assertEqual(first_test_project['stage'], 'Fake stage')
-        self.assertEqual(first_test_project['total_budget'], 9045389000)
+            self.assertTrue(content.find(str(item)))
 
-        # Second project (multiple coords, provinces)
-        second_test_project = filter(lambda x: x['name'] == 'Fake project 2', content['projects'])[0]
-        self.assertIn({'latitude': -33.399790, 'longitude': 25.443304}, second_test_project['coordinates'])
-        self.assertIn({'latitude': -30.399790, 'longitude': 15.443304}, second_test_project['coordinates'])
-        self.assertEqual(len(second_test_project['coordinates']), 2)
-        self.assertIn('Fake province 2', second_test_project['provinces'])
-        self.assertIn(' Fake province 3', second_test_project['provinces'])
-        self.assertEqual(len(second_test_project['provinces']), 2)
+        # Second project
+        self.assertTrue(content.find('Fake project 2'))
+        self.assertTrue(content.find('-33.399790'))
+        self.assertTrue(content.find('25.443304'))
+        self.assertTrue(content.find('-30.399790'))
+        self.assertTrue(content.find('15.443304'))
+        self.assertTrue(content.find('Fake province 2'))
+        self.assertTrue(content.find(' Fake province 3'))
 
 
 class DetailIntegrationTest(LiveServerTestCase):
@@ -280,7 +272,7 @@ class DetailIntegrationTest(LiveServerTestCase):
     @mock.patch('budgetportal.models.InfrastructureProjectPart.get_dataset', return_value=None)
     def test_missing_dataset_returns_404(self, mock_dataset):
         c = Client()
-        response = c.get('/json/infrastructure-projects/{}.json'.format(self.project.project_slug))
+        response = c.get('/infrastructure-projects/{}'.format(self.project.project_slug))
         self.assertEqual(response.status_code, 404)
 
     @mock.patch('budgetportal.models.InfrastructureProjectPart.get_dataset', return_value=MockDataset())
@@ -288,21 +280,17 @@ class DetailIntegrationTest(LiveServerTestCase):
     def test_success_with_projects(self, mock_dataset, mock_get):
         """ Test that it exists and that the correct years are linked. """
         c = Client()
-        response = c.get('/json/infrastructure-projects/{}.json'.format(self.project.project_slug))
-        content = response.json()['projects'][0]
+        response = c.get('/infrastructure-projects/{}'.format(
+            self.project.project_slug))
+        content = response.content
 
-        self.assertEqual(content['dataset_url'], 'fake path')
-        self.assertEqual(content['description'], self.project.project_description)
-        self.assertEqual(content['infrastructure_type'], self.project.infrastructure_type)
-        self.assertEqual(len(content['coordinates']), 0)
-        self.assertEqual(len(content['expenditure']), 7)
-        for item in self.project.build_complete_expenditure():
-            self.assertIn(item, content['expenditure'])
-        self.assertEqual(content['nature_of_investment'], self.project.nature_of_investment)
-        self.assertEqual(content['page_title'], '{} - vulekamali'.format(self.project.project_name))
-        self.assertEqual(content['projected_budget'], self.project.calculate_projected_expenditure())
-        self.assertEqual(len(content['provinces']), 1)
-        self.assertIn('', content['provinces'][0])
-        self.assertEqual(content['slug'], '/infrastructure-projects/{}'.format(self.project.project_slug))
-        self.assertEqual(content['stage'], self.project.current_project_stage)
-        self.assertEqual(content['total_budget'], self.project.total_project_cost)
+        self.assertTrue(content.find('fake path'))
+        self.assertTrue(content.find(self.project.project_description))
+        self.assertTrue(content.find(self.project.infrastructure_type))
+        self.assertTrue(content.find(self.project.nature_of_investment))
+        self.assertTrue(content.find('{} - vulekamali'.format(self.project.project_name)))
+        self.assertTrue(content.find(str(self.project.calculate_projected_expenditure())))
+        self.assertTrue(content.find('/infrastructure-projects/{}'.format(
+            self.project.project_slug)))
+        self.assertTrue(content.find(self.project.current_project_stage))
+        self.assertTrue(content.find(str(self.project.total_project_cost)))

--- a/budgetportal/tests/test_pages.py
+++ b/budgetportal/tests/test_pages.py
@@ -65,12 +65,37 @@ class BasicPagesTestCase(TestCase):
         self.assertTrue(content.find('National Budget Summary'))
         self.assertTrue(content.find('Provincial Budget Summary'))
 
+    def test_departments_list_page(self):
+        """Test that it loads and that some text is present"""
+        c = Client()
+        response = c.get('/2019-20/departments')
+        content = response.content
+        self.assertTrue(content.find('Department budgets for the 2019-20 financial year from National Treasury in partnership with IMALI YETHU.'))
+        self.assertTrue(content.find('National Department Budgets'))
+        self.assertTrue(content.find('Eastern Cape Department Budgets'))
+        self.assertTrue(content.find('Free State Department Budgets'))
+        self.assertTrue(content.find('Gauteng Department Budgets'))
+        self.assertTrue(content.find('KwaZulu-Natal Department Budgets'))
+        self.assertTrue(content.find('Limpopo Department Budgets'))
+        self.assertTrue(content.find('Mpumalanga Department Budgets'))
+        self.assertTrue(content.find('North West Department Budgets'))
+        self.assertTrue(content.find('Northern Cape Department Budgets'))
+        self.assertTrue(content.find('Western Cape Department Budgets'))
+
     def test_department_detail_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/2019-20/national/departments/the-presidency')
         content = response.content
         self.assertTrue(content.find('The Presidency budget data for the 2019-20 financial year'))
+
+    def test_department_preview_page(self):
+        """Test that it loads and that some text is present"""
+        c = Client()
+        response = c.get('2019-20/previews/national/south-africa/social-development')
+        content = response.content
+        self.assertTrue(content.find('Focus areas of this department'))
+        self.assertTrue(content.find('<a href="/2019-20/focus/social-development"'))
 
     def test_about_page(self):
         """Test that it loads and that some text is present"""
@@ -135,7 +160,7 @@ class BasicPagesTestCase(TestCase):
         content = response.content
         self.assertTrue(content.find("The Estimates of National Expenditure (ENE) publications describe in detail"))
 
-    def test_datasets_list_page(self):
+    def test_dataset_category_list_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/datasets')
@@ -149,6 +174,22 @@ class BasicPagesTestCase(TestCase):
         content = response.content
         self.assertTrue(content.find("Adjustments to the expenditure plans."))
 
+    def test_contributed_datasets_list_page(self):
+        """Test that it loads and that some text is present"""
+        # TODO: not implemented yet
+        c = Client()
+        response = c.get('/datasets/contributed')
+        content = response.content
+        self.assertTrue(content.find("Contibuted data and documentation for South African government budgets."))
+
+    def test_contributed_dataset_page(self):
+        """Test that it exists and that the correct years are linked"""
+        # TODO: not implemented yet
+        c = Client()
+        response = c.get('/datasets/contributed/a-guide-to-conducting-social-audits-in-south-africa')
+        content = response.content
+        self.assertTrue(content.find("Data contributed by: International Budget Partnership"))
+
     def test_search_page(self):
         """Test that it exists and that the correct years are linked"""
         c = Client()
@@ -157,3 +198,26 @@ class BasicPagesTestCase(TestCase):
         self.assertTrue(content.find('<li class="YearSelect-item is-active"><span class="YearSelect-link">2019-20</span></li>'))
         self.assertTrue(content.find('<a href="/2019-20/search-result" class="YearSelect-link">2019-20</a>'))
         self.assertTrue(content.find('<a href="/2016-17/search-result" class="YearSelect-link">2016-17</a>'))
+
+    def test_focus_page(self):
+        """Test that it loads and that some text is present"""
+        c = Client()
+        response = c.get('/2019-20/focus/social-development')
+        content = response.content
+        self.assertTrue(content.find('Social development'))
+        self.assertTrue(content.find('Contributing National Departments'))
+        self.assertTrue(content.find('Contributing Provincial Departments'))
+
+    def test_dataset_page(self):
+        """Test that it loads and that some text is present"""
+        c = Client()
+        response = c.get('datasets/adjusted-estimates-of-national-expenditure/adjusted-estimates-of-national-expenditure-2018-19')
+        content = response.content
+        self.assertTrue(content.find('What is an AENE?'))
+
+    def test_infrastructure_projects_list_page(self):
+        """Test that it loads and that some text is present"""
+        c = Client()
+        response = c.get('/infrastructure-projects')
+        content = response.content
+        self.assertTrue(content.find('national department infrastructure projects'))

--- a/budgetportal/tests/test_pages.py
+++ b/budgetportal/tests/test_pages.py
@@ -61,6 +61,9 @@ class BasicPagesTestCase(TestCase):
         response = c.get('/')
         content = response.content
         self.assertTrue(content.find('<a class="NavBar-link is-active" href="/">'))
+        self.assertTrue(content.find('Consolidated Budget Summary'))
+        self.assertTrue(content.find('National Budget Summary'))
+        self.assertTrue(content.find('Provincial Budget Summary'))
 
     def test_department_detail_page(self):
         """Test that it loads and that some text is present"""

--- a/budgetportal/tests/test_pages.py
+++ b/budgetportal/tests/test_pages.py
@@ -174,22 +174,6 @@ class BasicPagesTestCase(TestCase):
         content = response.content
         self.assertTrue(content.find("Adjustments to the expenditure plans."))
 
-    def test_contributed_datasets_list_page(self):
-        """Test that it loads and that some text is present"""
-        # TODO: not implemented yet
-        c = Client()
-        response = c.get('/datasets/contributed')
-        content = response.content
-        self.assertTrue(content.find("Contibuted data and documentation for South African government budgets."))
-
-    def test_contributed_dataset_page(self):
-        """Test that it exists and that the correct years are linked"""
-        # TODO: not implemented yet
-        c = Client()
-        response = c.get('/datasets/contributed/a-guide-to-conducting-social-audits-in-south-africa')
-        content = response.content
-        self.assertTrue(content.find("Data contributed by: International Budget Partnership"))
-
     def test_search_page(self):
         """Test that it exists and that the correct years are linked"""
         c = Client()

--- a/budgetportal/tests/test_pages.py
+++ b/budgetportal/tests/test_pages.py
@@ -7,7 +7,6 @@ from budgetportal.models import (
 from django.conf import settings
 from django.test import TestCase, Client
 from mock import patch, Mock
-import yaml
 
 # Hacky make sure we don't call out to openspending.
 import requests
@@ -59,17 +58,9 @@ class BasicPagesTestCase(TestCase):
     def test_overview_page(self):
         """Test that it exists and that the correct years are linked"""
         c = Client()
-        response = c.get('/2019-20.yaml')
-        content = yaml.load(response.content)
-        self.assertEqual(content['selected_tab'], 'homepage')
-
-    def test_department_detail_page_yaml(self):
-        """Test that it exists and that the correct years are linked"""
-        c = Client()
-        response = c.get('/2019-20/national/departments/the-presidency.yaml')
-        content = yaml.load(response.content)
-        self.assertEqual(content['financial_years'][-1]['id'], '2019-20')
-        self.assertEqual(content['financial_years'][0]['id'], '2016-17')
+        response = c.get('/')
+        content = response.content
+        self.assertTrue(content.find('<a class="NavBar-link is-active" href="/">'))
 
     def test_department_detail_page(self):
         """Test that it loads and that some text is present"""
@@ -158,7 +149,8 @@ class BasicPagesTestCase(TestCase):
     def test_search_page(self):
         """Test that it exists and that the correct years are linked"""
         c = Client()
-        response = c.get('/2019-20/search-result.yaml')
-        content = yaml.load(response.content)
-        self.assertEqual(content['financial_years'][-1]['id'], '2019-20')
-        self.assertEqual(content['financial_years'][0]['id'], '2016-17')
+        response = c.get('/2019-20/search-result')
+        content = response.content
+        self.assertTrue(content.find('<li class="YearSelect-item is-active"><span class="YearSelect-link">2019-20</span></li>'))
+        self.assertTrue(content.find('<a href="/2019-20/search-result" class="YearSelect-link">2019-20</a>'))
+        self.assertTrue(content.find('<a href="/2016-17/search-result" class="YearSelect-link">2016-17</a>'))

--- a/budgetportal/tests/test_pages.py
+++ b/budgetportal/tests/test_pages.py
@@ -49,6 +49,28 @@ class BasicPagesTestCase(TestCase):
         ckan_patch = patch('budgetportal.datasets.ckan')
         CKANMockClass = ckan_patch.start()
         CKANMockClass.action.package_search.return_value = {'results': []}
+        # self.addCleanup(ckan_patch.stop)
+
+        CKANMockClass.action.group_show.return_value = {'name': 'test', 'description': 'basic-test-description', 'title': 'test-slug'}
+        # self.addCleanup(ckan_patch.stop)
+
+        CKANMockClass.action.package_show.return_value = {
+            'state': '',
+            'resources': [],
+            'groups': [{'name': 'test-slug', 'description': 'basic-test-description', 'title': 'test-slug'}],
+            "name": "test-2018-19",
+            "title": "Test 2018/19",
+            "id": "9c7af295",
+            "metadata_created": "2018-11-30T05:06:49.588395",
+            "metadata_modified": "2018-12-03T10:07:22.333285",
+            "author": "Vulekamali ",
+            "author_email": "",
+            "license_title": "Creative Commons Attribution Share-Alike",
+            "license_url": "http://www.opendefinition.org/licenses/cc-by-sa",
+            "organization": {
+                "name": "basic-organization-slug"
+            },
+        }
         self.addCleanup(ckan_patch.stop)
 
         dataset_patch = patch('budgetportal.datasets.Dataset.get_latest_cpi_resource', return_value=('2018-19', '5b315ff0-55e9-4ba8-b88c-2d70093bfe9d'))
@@ -59,149 +81,141 @@ class BasicPagesTestCase(TestCase):
         """Test that it exists and that the correct years are linked"""
         c = Client()
         response = c.get('/')
-        content = response.content
-        self.assertTrue(content.find('<a class="NavBar-link is-active" href="/">'))
-        self.assertTrue(content.find('Consolidated Budget Summary'))
-        self.assertTrue(content.find('National Budget Summary'))
-        self.assertTrue(content.find('Provincial Budget Summary'))
+
+        self.assertContains(response, '<a class="NavBar-link is-active" href="/">')
+        self.assertContains(response, 'About Vulekamali')
+        self.assertContains(response, 'Vulekamali is a project by the South African National Treasury and Imali Yethu')
 
     def test_departments_list_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/2019-20/departments')
-        content = response.content
-        self.assertTrue(content.find('Department budgets for the 2019-20 financial year from National Treasury in partnership with IMALI YETHU.'))
-        self.assertTrue(content.find('National Department Budgets'))
-        self.assertTrue(content.find('Eastern Cape Department Budgets'))
-        self.assertTrue(content.find('Free State Department Budgets'))
-        self.assertTrue(content.find('Gauteng Department Budgets'))
-        self.assertTrue(content.find('KwaZulu-Natal Department Budgets'))
-        self.assertTrue(content.find('Limpopo Department Budgets'))
-        self.assertTrue(content.find('Mpumalanga Department Budgets'))
-        self.assertTrue(content.find('North West Department Budgets'))
-        self.assertTrue(content.find('Northern Cape Department Budgets'))
-        self.assertTrue(content.find('Western Cape Department Budgets'))
+
+        self.assertContains(response, 'Department Budgets for 2019-20 - vulekamali')
 
     def test_department_detail_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/2019-20/national/departments/the-presidency')
-        content = response.content
-        self.assertTrue(content.find('The Presidency budget data for the 2019-20 financial year'))
+
+        self.assertContains(response, 'The Presidency budget data for the 2019-20 financial year')
 
     def test_department_preview_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
-        response = c.get('2019-20/previews/national/south-africa/social-development')
-        content = response.content
-        self.assertTrue(content.find('Focus areas of this department'))
-        self.assertTrue(content.find('<a href="/2019-20/focus/social-development"'))
+        response = c.get('/2019-20/previews/national/south-africa/social-development')
+
+        self.assertContains(response, '<div data-webapp="preview-pages"></div>')
+        self.assertContains(response, '=https://vulekamali.gov.za/2019-20/previews/national/south-africa/social-development\">')
 
     def test_about_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/about')
-        content = response.content
-        self.assertTrue(content.find('Learn more about the new Online Budget Data Portal'))
+
+        self.assertContains(response, 'Learn more about the new Online Budget Data Portal')
 
     def test_events_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/events')
-        content = response.content
-        self.assertTrue(content.find('Join us at a Vulekamali event in your area'))
+
+        self.assertContains(response, 'Join us at a Vulekamali event in your area')
 
     def test_videos_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/videos')
-        content = response.content
-        self.assertTrue(content.find('Learn more about the new Online Budget Data Portal'))
+
+        self.assertContains(response, 'Learn more about the new Online Budget Data Portal')
 
     def test_terms_and_conditions_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/terms-and-conditions')
-        content = response.content
-        self.assertTrue(content.find('Users are encouraged to utilise this data'))
+
+        self.assertContains(response, 'Users are encouraged to utilise this data')
 
     def test_resources_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/resources')
         content = response.content
-        self.assertTrue(content.find('The Budget Process and Public Participation'))
+        self.assertContains(response, 'The Budget Process and Public Participation')
 
     def test_glossary_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/glossary')
-        content = response.content
-        self.assertTrue(content.find('Accounting officer'))
+
+        self.assertContains(response, '<title>Glossary - vulekamali</title>')
 
     def test_faq_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/faq')
-        content = response.content
-        self.assertTrue(content.find('When is the budget data updated?'))
+
+        self.assertContains(response, 'When is the budget data updated?')
 
     def test_guides_list_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/guides')
-        content = response.content
-        self.assertTrue(content.find("South Africa's National and Provincial budget data from National Treasury in partnership with IMALI YETHU."))
+
+        self.assertContains(response, "Dataset Guides")
+        self.assertContains(response, "Estimates of National Expenditure (ENE)")
+        self.assertContains(response, "Performance and Expenditure Reviews (PER)")
 
     def test_guide_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/guides/estimates-of-national-expenditure')
-        content = response.content
-        self.assertTrue(content.find("The Estimates of National Expenditure (ENE) publications describe in detail"))
+
+        self.assertContains(response, "The Estimates of National Expenditure (ENE) publications describe in detail")
 
     def test_dataset_category_list_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/datasets')
-        content = response.content
-        self.assertTrue(content.find("Data and Analysis"))
+
+        self.assertContains(response, "Data and Analysis")
 
     def test_dataset_category_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
-        response = c.get('/datasets/adjusted-estimates-of-national-expenditure')
-        content = response.content
-        self.assertTrue(content.find("Adjustments to the expenditure plans."))
+        response = c.get('/datasets/test-slug')
+
+        self.assertContains(response, "<title>test-slug - vulekamali</title>")
+        self.assertContains(response, "basic-test-description")
+        self.assertContains(response, "Learn more about test-slug")
 
     def test_search_page(self):
         """Test that it exists and that the correct years are linked"""
         c = Client()
-        response = c.get('/2019-20/search-result')
-        content = response.content
-        self.assertTrue(content.find('<li class="YearSelect-item is-active"><span class="YearSelect-link">2019-20</span></li>'))
-        self.assertTrue(content.find('<a href="/2019-20/search-result" class="YearSelect-link">2019-20</a>'))
-        self.assertTrue(content.find('<a href="/2016-17/search-result" class="YearSelect-link">2016-17</a>'))
+        response = c.get('/2019-20/search-result/?search_type=full-search&search_string=a&search=a')
+
+        self.assertContains(response, '<title>Search Results - vulekamali</title>')
+        self.assertContains(response, '<div data-component="SearchResult" data-year="2019-20" data-root></div>')
 
     def test_focus_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/2019-20/focus/social-development')
-        content = response.content
-        self.assertTrue(content.find('Social development'))
-        self.assertTrue(content.find('Contributing National Departments'))
-        self.assertTrue(content.find('Contributing Provincial Departments'))
+
+        self.assertContains(response, '<div data-webapp="focus-areas-preview"></div>')
 
     def test_dataset_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
-        response = c.get('datasets/adjusted-estimates-of-national-expenditure/adjusted-estimates-of-national-expenditure-2018-19')
-        content = response.content
-        self.assertTrue(content.find('What is an AENE?'))
+        response = c.get('/datasets/test-slug/test-2018-19')
+
+        self.assertContains(response, '<title>Test 2018/19 - vulekamali</title>')
+        self.assertContains(response, '<a href="/datasets/test-slug">test-slug</a>')
+        self.assertContains(response, 'Test 2018/19')
 
     def test_infrastructure_projects_list_page(self):
         """Test that it loads and that some text is present"""
         c = Client()
         response = c.get('/infrastructure-projects')
-        content = response.content
-        self.assertTrue(content.find('national department infrastructure projects'))
+
+        self.assertContains(response, '<div data-webapp="infrastructure-pages" class="infrastructure-projects"></div>')

--- a/budgetportal/urls.py
+++ b/budgetportal/urls.py
@@ -55,9 +55,6 @@ urlpatterns = [
 
     # Homepage
     url(r'^$', cache_page(CACHE_SECS)(views.homepage)),
-    # Financial year home page
-    url(r'^(?P<financial_year_id>\d{4}-\d{2}).yaml$',
-        cache_page(CACHE_SECS)(views.homepage_yaml)),
 
     # Search results
     url(r'^json/static-search.json', cache_page(CACHE_SECS)(views.static_search_data)),

--- a/budgetportal/urls.py
+++ b/budgetportal/urls.py
@@ -29,15 +29,10 @@ urlpatterns = [
 
     url(r'^(?P<financial_year_id>\d{4}-\d{2})'
         '/focus/(?P<focus_slug>[\w-]+)/?$', cache_page(CACHE_SECS)(views.focus_area_preview)),
-    url(r'^(?P<financial_year_id>\d{4}-\d{2})'
-        '/focus.yaml', cache_page(CACHE_SECS)(views.focus_preview_yaml)),
     url(r'^json/(?P<financial_year_id>\d{4}-\d{2})'
         '/focus.json', cache_page(CACHE_SECS)(views.focus_preview_json)),
 
     # National and provincial treemap data
-    url(r'^(?P<financial_year_id>\d{4}-\d{2})'
-        '/(?P<sphere_slug>[\w-]+)'
-        '/(?P<phase_slug>[\w-]+).yaml$', cache_page(CACHE_SECS)(views.treemaps_yaml)),
     url(r'^json/(?P<financial_year_id>\d{4}-\d{2})'
         '/(?P<sphere_slug>[\w-]+)'
         '/(?P<phase_slug>[\w-]+).json', cache_page(CACHE_SECS)(views.treemaps_json)),
@@ -48,11 +43,6 @@ urlpatterns = [
         '/(?P<sphere_slug>[\w-]+)'
         '/(?P<government_slug>[\w-]+)'
         '/(?P<department_slug>[\w-]+)$', cache_page(CACHE_SECS)(views.department_preview)),
-    url(r'^(?P<financial_year_id>\d{4}-\d{2})'
-        '/previews'
-        '/(?P<sphere_slug>[\w-]+)'
-        '/(?P<government_slug>[\w-]+)'
-        '/(?P<phase_slug>[\w-]+).yaml$', cache_page(CACHE_SECS)(views.department_preview_yaml)),
     url(r'^json/(?P<financial_year_id>\d{4}-\d{2})'
         '/previews'
         '/(?P<sphere_slug>[\w-]+)'
@@ -60,8 +50,6 @@ urlpatterns = [
         '/(?P<phase_slug>[\w-]+).json', cache_page(CACHE_SECS)(views.department_preview_json)),
 
     # Consolidated
-    url(r'^(?P<financial_year_id>\d{4}-\d{2})'
-        '/consolidated.yaml', cache_page(CACHE_SECS)(views.consolidated_treemap_yaml)),
     url(r'^json/(?P<financial_year_id>\d{4}-\d{2})'
         '/consolidated.json', cache_page(CACHE_SECS)(views.consolidated_treemap_json)),
 
@@ -72,8 +60,6 @@ urlpatterns = [
         cache_page(CACHE_SECS)(views.homepage_yaml)),
 
     # Search results
-    url(r'^(?P<financial_year_id>\d{4}-\d{2})/search-result.yaml',
-        cache_page(CACHE_SECS)(views.search_result_page_yaml)),
     url(r'^json/static-search.json', cache_page(CACHE_SECS)(views.static_search_data)),
 
     # Department list as CSV
@@ -118,42 +104,31 @@ urlpatterns = [
 
     # Dataset category list
     url(r'^datasets/?$', views.dataset_category_list_page, name="dataset-landing-page"),
-    url(r'^datasets.yaml$', cache_page(CACHE_SECS)(views.dataset_category_list_yaml)),
 
 
     # Dataset categories
     url(r'^datasets/contributed/?$', views.contributed_datasets_list, name="contributed-datasets"),
     url(r'^datasets/contributed/(?P<dataset_slug>[-\w]+)/?$', views.contributed_dataset, name="contributed-dataset"),
     url(r'^datasets/(?P<category_slug>[-\w]+)/?$', views.dataset_category_page, name="dataset-category"),
-    url(r'^datasets/(?P<category_slug>[\w-]+).yaml$', cache_page(CACHE_SECS)(views.dataset_category_yaml)),
 
     # Detaset detail
     url(r'^datasets/(?P<category_slug>[-\w]+)/(?P<dataset_slug>[-\w]+)/?$', views.dataset_page, name="dataset"),
-    url(r'^datasets/(?P<category_slug>[\w-]+)/(?P<dataset_slug>[\w-]+).yaml$', cache_page(CACHE_SECS)(views.dataset_yaml)),
 
     url(r'^(?P<financial_year_id>\d{4}-\d{2})/search-result/?$', views.search_result, name="search-result"),
 
     # Infrastructure projects
     url(r"^infrastructure-projects/?$", views.infrastructure_project_list, name="infrastructure-project-list"),
-    url(r'^infrastructure-projects.yaml$', cache_page(CACHE_SECS)(views.infrastructure_projects_overview_yaml)),
     url(r'^json/infrastructure-projects.json$', cache_page(CACHE_SECS)(views.infrastructure_projects_overview_json)),
     url(r'^json/infrastructure-projects/(?P<project_slug>[\w-]+).json$', cache_page(CACHE_SECS)(views.infrastructure_project_detail_json)),
     url(r'^infrastructure-projects/(?P<project_slug>[\w-]+)$', cache_page(CACHE_SECS)(views.infrastructure_project_detail)),
-    url(r'^infrastructure-projects/(?P<project_slug>[\w-]+).yaml$',
-        cache_page(CACHE_SECS)(views.infrastructure_project_detail_yaml)),
 
     # Department List
     url(r'^(?P<financial_year_id>\d{4}-\d{2})'
         '/departments$', cache_page(CACHE_SECS)(views.department_list)),
-    url(r'^(?P<financial_year_id>\d{4}-\d{2})'
-        '/departments.yaml', cache_page(CACHE_SECS)(views.department_list_yaml)),
     # Department detail
     # - National
     url(r'^(?P<financial_year_id>\d{4}-\d{2})/national/departments/(?P<department_slug>[\w-]+)$',
         cache_page(CACHE_SECS)(views.department_page),
-        kwargs={'sphere_slug': 'national', 'government_slug': 'south-africa'}),
-    url(r'^(?P<financial_year_id>\d{4}-\d{2})/national/departments/(?P<department_slug>[\w-]+).yaml$',
-        cache_page(CACHE_SECS)(views.department_yaml),
         kwargs={'sphere_slug': 'national', 'government_slug': 'south-africa'}),
     # - Provincial
     url(r'^(?P<financial_year_id>[\w-]+)'
@@ -161,11 +136,6 @@ urlpatterns = [
         '/(?P<government_slug>[\w-]+)'
         '/departments'
         '/(?P<department_slug>[\w-]+)$', cache_page(CACHE_SECS)(views.department_page)),
-    url(r'^(?P<financial_year_id>[\w-]+)'
-        '/(?P<sphere_slug>[\w-]+)'
-        '/(?P<government_slug>[\w-]+)'
-        '/departments'
-        '/(?P<department_slug>[\w-]+).yaml$', cache_page(CACHE_SECS)(views.department_yaml)),
 ]
 
 if settings.DEBUG_TOOLBAR:

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -40,7 +40,6 @@ COMMON_DESCRIPTION_ENDING = "from National Treasury in partnership with IMALI YE
 
 def homepage(request, financial_year_id="2019-20"):
     """
-        View of a financial year homepage, e.g. /2017-18
     """
     titles = {'whyBudgetIsImportant', 'howCanTheBudgetPortalHelpYou', 'theBudgetProcess'}
     videos = Video.objects.filter(title_id__in=titles)

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -472,6 +472,10 @@ def infrastructure_project_detail_json(request, project_slug):
 
 def infrastructure_project_detail(request, project_slug):
     navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
+    dataset_response = infrastructure_project_detail_data(project_slug)
+    if isinstance(dataset_response, HttpResponse):
+        return dataset_response
+
     context = {
         'page': {
             'layout': 'infrastructure_project',
@@ -480,7 +484,7 @@ def infrastructure_project_detail(request, project_slug):
         'site': {
             'data': {
                 'navbar': read_object_from_yaml(navbar_data_file_path),
-                'dataset': infrastructure_project_detail_data(project_slug),
+                'dataset': dataset_response,
             },
             'latest_year': '2019-20'
         },

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -38,42 +38,32 @@ COMMON_DESCRIPTION = "South Africa's National and Provincial budget data "
 COMMON_DESCRIPTION_ENDING = "from National Treasury in partnership with IMALI YETHU."
 
 
-def homepage_context(request, financial_year_id):
+def homepage(request, financial_year_id="2019-20"):
     """
-    View of a financial year homepage, e.g. /2017-18
+        View of a financial year homepage, e.g. /2017-18
     """
-    year = get_object_or_404(FinancialYear, slug=financial_year_id)
-    revenue_data = year.get_budget_revenue()
-
-    context = {
-        'revenue': revenue.sort_categories(revenue_data),
-        'selected_financial_year': None,
-        'financial_years': [],
-        'selected_tab': 'homepage',
-        'slug': financial_year_id,
-        'title': "South African Government Budgets %s - vulekamali" % year.slug,
-        'description': COMMON_DESCRIPTION + COMMON_DESCRIPTION_ENDING,
-        'url_path': year.get_url_path(),
-    }
-    return context
-
-
-def homepage(request):
     titles = {'whyBudgetIsImportant', 'howCanTheBudgetPortalHelpYou', 'theBudgetProcess'}
     videos = Video.objects.filter(title_id__in=titles)
 
     navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
-    homepage_data_file_path = str(settings.ROOT_DIR.path('_data/index.yaml'))
 
-    context = homepage_context(request, financial_year_id="2019-20")
-    context['navbar'] = read_object_from_yaml(navbar_data_file_path)
-    context['videos'] = videos
-    context['latest_year'] = '2019-20'
+    year = get_object_or_404(FinancialYear, slug=financial_year_id)
+    revenue_data = year.get_budget_revenue()
+
+    context = {'revenue': revenue.sort_categories(revenue_data),
+               'selected_financial_year': None, 'financial_years': [],
+               'selected_tab': 'homepage', 'slug': financial_year_id,
+               'title': "South African Government Budgets %s - vulekamali" % year.slug,
+               'description': COMMON_DESCRIPTION + COMMON_DESCRIPTION_ENDING,
+               'url_path': year.get_url_path(),
+               'navbar': read_object_from_yaml(navbar_data_file_path),
+               'videos': videos, 'latest_year': '2019-20'}
 
     return render(request, 'homepage.html', context=context)
 
 
-def search_result_page_context(request, financial_year_id):
+def search_result(request, financial_year_id):
+    navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
     slug = 'search-result'
     context = {
         'financial_years': [],
@@ -95,12 +85,6 @@ def search_result_page_context(request, financial_year_id):
                 'url_path': "/%s/%s" % (year.slug, slug),
             },
         })
-    return context
-
-
-def search_result(request, financial_year_id):
-    navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
-    context = search_result_page_context(request, financial_year_id)
     context['navbar'] = read_object_from_yaml(navbar_data_file_path)
     context['latest_year'] = '2019-20'
     return render(request, 'search-result.html', context=context)
@@ -215,7 +199,7 @@ def department_list_data(financial_year_id):
     return page_data
 
 
-def department_context(financial_year_id, sphere_slug, government_slug, department_slug):
+def department_page(request, financial_year_id, sphere_slug, government_slug, department_slug):
     department = None
     selected_year = get_object_or_404(FinancialYear, slug=financial_year_id)
 
@@ -355,12 +339,6 @@ def department_context(financial_year_id, sphere_slug, government_slug, departme
         },
         'website_url': department.get_latest_website_url(),
     }
-
-    return context, department
-
-
-def department_page(request, financial_year_id, sphere_slug, government_slug, department_slug):
-    context, department = department_context(financial_year_id, sphere_slug, government_slug, department_slug)
     navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
     context['navbar'] = read_object_from_yaml(navbar_data_file_path)
     context['latest_year'] = '2019-20'
@@ -730,27 +708,21 @@ def guides(request, slug):
     return render(request, template, context=context)
 
 
-def dataset_category_list_context():
-    return {
-        'categories': [category_fields(c) for c in Category.get_all()],
-        'selected_tab': 'datasets',
-        'slug': 'datasets',
-        'name': 'Datasets and Analysis',
-        'title': 'Datasets and Analysis - vulekamali',
-        'url_path': '/datasets',
-    }
-
-
 def dataset_category_list_page(request):
-    context = dataset_category_list_context()
     navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
-    context['navbar'] = read_object_from_yaml(navbar_data_file_path)
-    context['latest_year'] = '2019-20'
+    context = {'categories': [category_fields(c) for c in Category.get_all()],
+               'selected_tab': 'datasets', 'slug': 'datasets',
+               'name': 'Datasets and Analysis',
+               'title': 'Datasets and Analysis - vulekamali',
+               'url_path': '/datasets',
+               'navbar': read_object_from_yaml(navbar_data_file_path),
+               'latest_year': '2019-20'}
 
     return render(request, 'datasets.html', context=context)
 
 
-def dataset_category_context(category_slug):
+def dataset_category_page(request, category_slug):
+    navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
     category = Category.get_by_slug(category_slug)
     context = {
         'datasets': [],
@@ -771,13 +743,6 @@ def dataset_category_context(category_slug):
         del field_subset['usage']
         del field_subset['importance']
         context['datasets'].append(field_subset)
-
-    return context
-
-
-def dataset_category_page(request, category_slug):
-    navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
-    context = dataset_category_context(category_slug)
     context['navbar'] = read_object_from_yaml(navbar_data_file_path)
     context['latest_year'] = '2019-20'
     context['guide'] = guide_data.get(category_guides.get(category_slug, None), None),
@@ -792,7 +757,7 @@ def contributed_datasets_list(request):
     return render(request, 'contributed_data_category.html', context=context)
 
 
-def dataset_context(category_slug, dataset_slug):
+def dataset_page(request, category_slug, dataset_slug):
     dataset = Dataset.fetch(dataset_slug)
     assert (dataset.category.slug == category_slug)
 
@@ -811,11 +776,6 @@ def dataset_context(category_slug, dataset_slug):
     }
 
     context.update(dataset_fields(dataset))
-    return context
-
-
-def dataset_page(request, category_slug, dataset_slug):
-    context = dataset_context(category_slug, dataset_slug)
     navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
     context['navbar'] = read_object_from_yaml(navbar_data_file_path)
     context['latest_year'] = '2019-20'

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -39,8 +39,6 @@ COMMON_DESCRIPTION_ENDING = "from National Treasury in partnership with IMALI YE
 
 
 def homepage(request, financial_year_id="2019-20"):
-    """
-    """
     titles = {'whyBudgetIsImportant', 'howCanTheBudgetPortalHelpYou', 'theBudgetProcess'}
     videos = Video.objects.filter(title_id__in=titles)
 

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -721,8 +721,7 @@ def dataset_category_list_page(request):
     return render(request, 'datasets.html', context=context)
 
 
-def dataset_category_page(request, category_slug):
-    navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
+def dataset_category_context(category_slug):
     category = Category.get_by_slug(category_slug)
     context = {
         'datasets': [],
@@ -743,6 +742,13 @@ def dataset_category_page(request, category_slug):
         del field_subset['usage']
         del field_subset['importance']
         context['datasets'].append(field_subset)
+
+    return context
+
+
+def dataset_category_page(request, category_slug):
+    navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
+    context = dataset_category_context(category_slug)
     context['navbar'] = read_object_from_yaml(navbar_data_file_path)
     context['latest_year'] = '2019-20'
     context['guide'] = guide_data.get(category_guides.get(category_slug, None), None),
@@ -757,7 +763,7 @@ def contributed_datasets_list(request):
     return render(request, 'contributed_data_category.html', context=context)
 
 
-def dataset_page(request, category_slug, dataset_slug):
+def dataset_context(category_slug, dataset_slug):
     dataset = Dataset.fetch(dataset_slug)
     assert (dataset.category.slug == category_slug)
 
@@ -776,6 +782,11 @@ def dataset_page(request, category_slug, dataset_slug):
     }
 
     context.update(dataset_fields(dataset))
+    return context
+
+
+def dataset_page(request, category_slug, dataset_slug):
+    context = dataset_context(category_slug, dataset_slug)
     navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
     context['navbar'] = read_object_from_yaml(navbar_data_file_path)
     context['latest_year'] = '2019-20'

--- a/budgetportal/views.py
+++ b/budgetportal/views.py
@@ -58,14 +58,6 @@ def homepage_context(request, financial_year_id):
     return context
 
 
-def homepage_yaml(request, financial_year_id):
-    context = homepage_context(request, financial_year_id)
-    response_yaml = yaml.safe_dump(context,
-                                   default_flow_style=False,
-                                   encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
-
-
 def homepage(request):
     titles = {'whyBudgetIsImportant', 'howCanTheBudgetPortalHelpYou', 'theBudgetProcess'}
     videos = Video.objects.filter(title_id__in=titles)
@@ -104,16 +96,6 @@ def search_result_page_context(request, financial_year_id):
             },
         })
     return context
-
-
-def search_result_page_yaml(request, financial_year_id):
-    context = search_result_page_context(request, financial_year_id)
-    response_yaml = yaml.safe_dump(
-        context,
-        default_flow_style=False,
-        encoding='utf-8'
-    )
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
 
 
 def search_result(request, financial_year_id):
@@ -387,12 +369,6 @@ def department_page(request, financial_year_id, sphere_slug, government_slug, de
     return render(request, 'department.html', context=context)
 
 
-def department_yaml(request, financial_year_id, sphere_slug, government_slug, department_slug):
-    context, department = department_context(financial_year_id, sphere_slug, government_slug, department_slug)
-    response_yaml = yaml.safe_dump(context, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
-
-
 def infrastructure_projects_overview(request):
     """ Overview page to showcase all featured infrastructure projects """
     infrastructure_projects = InfrastructureProjectPart.objects.filter(featured=True).distinct('project_slug')
@@ -435,12 +411,6 @@ def infrastructure_projects_overview(request):
         'selected_tab': 'infrastructure-projects',
         'title': 'Infrastructure Projects - vulekamali',
     }
-
-
-def infrastructure_projects_overview_yaml(request):
-    response = infrastructure_projects_overview(request)
-    response_yaml = yaml.safe_dump(response, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
 
 
 def infrastructure_projects_overview_json(request):
@@ -506,15 +476,6 @@ def infrastructure_project_detail_data(project_slug):
         'selected_tab': 'infrastructure-projects',
         'title': 'Infrastructure Projects - vulekamali',
     }
-
-
-def infrastructure_project_detail_yaml(request, project_slug):
-    response = infrastructure_project_detail_data(project_slug)
-    if isinstance(response, HttpResponse):
-        return response
-
-    response_yaml = yaml.safe_dump(response, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
 
 
 def infrastructure_project_detail_json(request, project_slug):
@@ -780,12 +741,6 @@ def dataset_category_list_context():
     }
 
 
-def dataset_category_list_yaml(request):
-    context = dataset_category_list_context()
-    response_yaml = yaml.safe_dump(context, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
-
-
 def dataset_category_list_page(request):
     context = dataset_category_list_context()
     navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
@@ -818,12 +773,6 @@ def dataset_category_context(category_slug):
         context['datasets'].append(field_subset)
 
     return context
-
-
-def dataset_category_yaml(request, category_slug):
-    context = dataset_category_context(category_slug)
-    response_yaml = yaml.safe_dump(context, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
 
 
 def dataset_category_page(request, category_slug):
@@ -865,12 +814,6 @@ def dataset_context(category_slug, dataset_slug):
     return context
 
 
-def dataset_yaml(request, category_slug, dataset_slug):
-    context = dataset_context(category_slug, dataset_slug)
-    response_yaml = yaml.safe_dump(context, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
-
-
 def dataset_page(request, category_slug, dataset_slug):
     context = dataset_context(category_slug, dataset_slug)
     navbar_data_file_path = str(settings.ROOT_DIR.path('_data/navbar.yaml'))
@@ -906,12 +849,6 @@ def department_list(request, financial_year_id):
     return render(request, 'department_list.html', context=context)
 
 
-def department_list_yaml(request, financial_year_id):
-    page_data = department_list_data(financial_year_id)
-    response_yaml = yaml.safe_dump(page_data, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
-
-
 def department_list_json(request, financial_year_id):
     response_json = json.dumps(
         department_list_data(financial_year_id),
@@ -935,12 +872,6 @@ def treemaps_data(financial_year_id, phase_slug, sphere_slug):
     return page_data
 
 
-def treemaps_yaml(request, financial_year_id, phase_slug, sphere_slug):
-    response = treemaps_data(financial_year_id, phase_slug, sphere_slug)
-    response_yaml = yaml.safe_dump(response, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
-
-
 def treemaps_json(request, financial_year_id, phase_slug, sphere_slug):
     response_json = json.dumps(
         treemaps_data(financial_year_id, phase_slug, sphere_slug),
@@ -958,12 +889,6 @@ def consolidated_treemap(financial_year_id):
     return page_data
 
 
-def consolidated_treemap_yaml(request, financial_year_id):
-    response = consolidated_treemap(financial_year_id)
-    response_yaml = yaml.safe_dump(response, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
-
-
 def consolidated_treemap_json(request, financial_year_id):
     response_json = json.dumps(
         consolidated_treemap(financial_year_id),
@@ -979,12 +904,6 @@ def focus_preview_data(financial_year_id):
     financial_year = FinancialYear.objects.get(slug=financial_year_id)
     page_data = get_focus_area_preview(financial_year)
     return page_data
-
-
-def focus_preview_yaml(request, financial_year_id):
-    response = focus_preview_data(financial_year_id)
-    response_yaml = yaml.safe_dump(response, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
 
 
 def focus_preview_json(request, financial_year_id):
@@ -1019,12 +938,6 @@ def focus_area_preview(request, financial_year_id, focus_slug):
 def department_preview_data(financial_year_id, sphere_slug, government_slug, phase_slug):
     page_data = get_preview_page(financial_year_id, phase_slug, government_slug, sphere_slug)
     return page_data
-
-
-def department_preview_yaml(request, financial_year_id, sphere_slug, government_slug, phase_slug):
-    response = department_preview_data(financial_year_id, sphere_slug, government_slug, phase_slug)
-    response_yaml = yaml.safe_dump(response, default_flow_style=False, encoding='utf-8')
-    return HttpResponse(response_yaml, content_type='text/x-yaml')
 
 
 def department_preview_json(request, financial_year_id, sphere_slug, government_slug, phase_slug):


### PR DESCRIPTION
- [x] Remove .yaml endpoints from urls.py 
- [x] Remove the .yaml endpoint tests 
- [x] Remove .yaml view code 
- [x] for views whose context function is now only used for the HTML view, merge the view function and the context function. 
- [x] Ensure there is a smoke test for each HTML view simply checking for the presence of a string that would only be present if the page loaded the data it uses correctly.