### PR TITLE
Remove gevent setup which is breaking at least admin in dev at least

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -6,4 +6,4 @@ set -o nounset
 
 
 python manage.py collectstatic --noinput
-gunicorn $GUNICORN_WORKERS_ARG --worker-class gevent budgetportal.wsgi:application --log-file - --bind 0.0.0.0:$PORT
+gunicorn $GUNICORN_WORKERS_ARG budgetportal.wsgi:application --log-file - --bind 0.0.0.0:$PORT

--- a/budgetportal/wsgi.py
+++ b/budgetportal/wsgi.py
@@ -7,16 +7,9 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 """
 
-from psycogreen.gevent import patch_psycopg
 import os
 
 from django.core.wsgi import get_wsgi_application
-
-from gevent import monkey
-
-monkey.patch_all()
-
-patch_psycopg()
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "budgetportal.settings")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       args:
         USER_ID: ${USER_ID:-1001}
         GROUP_ID: ${GROUP_ID:-1001}
-    command: python manage.py runserver_plus --nopin 0.0.0.0:8000
+    command: python manage.py runserver 0.0.0.0:8000
     environment:
       - TAG_MANAGER_ID
       - DATABASE_URL=postgresql://budgetportal:devpassword@db/budgetportal


### PR DESCRIPTION
I get this error when visiting admin in dev.

It looks like runserver is actually running budgetportal/wsgi.py

![Screenshot_2023-09-15_09-55-14](https://github.com/vulekamali/datamanager/assets/235801/b0f3ab4e-7630-43f1-9be0-3407e98d73f9)
